### PR TITLE
Check for existence of destination dir in install script

### DIFF
--- a/install
+++ b/install
@@ -127,17 +127,15 @@ curr_dir=$(dirname "$0")
 cd "${curr_dir}" || exit 1
 
 # make sure destination is writable
-if [ ! -w "${dest_path}" ]; then
-  _denv_error "Cannot write into ${dest_path}, permission denied"
-  exit 1
+if [ ! -d "${dest_path}" ]; then
+  mkdir -p ${dest_path}
 fi
 if [ ! -w "${man_dest_path}" ]; then
   _denv_error "Cannot write into ${man_dest_path}, permission denied"
   exit 1
 fi
-if [ ! -w "${completion_dest_path}" ]; then
-  _denv_error "Cannot write into ${completion_dest_path}, permission denied"
-  exit 1
+if [ ! -d "${completion_dest_path}" ]; then
+  mkdir -p ${completion_dest_path}
 fi
 
 # if files are available here, install files in dest directory


### PR DESCRIPTION
When running the install script, some of the directories in `~/.local` did not exist resulting in a `Cannot write into, permission denied` error. This PR updates the install script such that the installation directory is created if it doesn't exists. 

After the updates, I ran the `install` script and it installed everything as expected.