### PR TITLE
docker/podman requires runtime flag to connect network

### DIFF
--- a/denv
+++ b/denv
@@ -235,6 +235,7 @@ _denv_run() {
       # shellcheck disable=SC2086
       ${denv_runner} run \
         --rm \
+        --network host \
         ${interactive} \
         ${mounts} \
         --hostname "${_hostname}" \


### PR DESCRIPTION
tell those runners to use host network as its own - apptainer/singularity already share the host network by default so no changes are needed for those runners.

I manually tested this by using the jupyter datascience notebook.
```
mkdir net-test
cd net-test
denv init jupyter/datascience-notebook
denv jupyter lab --no-browser
# was able to connect to localhost link displayed by jupyter
```