### PR TITLE
set version script

### DIFF
--- a/ci/check
+++ b/ci/check
@@ -3,4 +3,4 @@ shellcheck \
   --color=always \
   denv _denv_entrypoint \
   install uninstall \
-  ci/test ci/check
+  ci/test ci/check ci/set-version

--- a/ci/set-version
+++ b/ci/set-version
@@ -43,10 +43,18 @@ help() {
 
  USAGE:
 
-  ./ci/set-version X.Y.Z
+  ./ci/set-version [options] X.Y.Z
 
  ARGUMENTS
   X.Y.Z : new version string to use
+
+ OPTIONS
+  -h, --help : print this help and exit
+  --commit   : make a commit, tag, and push
+  --dry-run  : just show what would be done in
+               a git-diff-like format
+  --force    : ignore if there are untracked
+               or modified files in your git working tree
 
 HELP
 }
@@ -56,24 +64,77 @@ if [ "$#" -eq 0 ]; then
   exit 0
 fi
 
-if [ "$#" -gt 1 ]; then
-  help
-  error "./ci/set-version requires one and only one argument"
+version=""
+commit=0
+dry_run=0
+force=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      help
+      exit 0
+      ;;
+    --commit)
+      commit=1
+      ;;
+    --dry-run)
+      dry_run=1
+      ;;
+    --force)
+      force=1
+      ;;
+    -*)
+      error "Unrecognized option '$1'"
+      exit 1
+      ;;
+    *)
+      if [ -z "${version}" ]; then
+        version="$1"
+      else
+        error "./ci/set-version only accepts a single argument"
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ -z "${version}" ]; then
+  error "need to define the version we should use"
   exit 1
 fi
 
-if ! validate_version "${1}"; then
-  error "version string '${1}' does not match X.Y.Z"
+if ! validate_version "${version}"; then
+  error "version string '${version}' does not match X.Y.Z"
   exit 1
 fi
 
-if check_changes; then
+if ! check_changes && [ "${force}" -eq "0" ]; then
   error "Some untracked or modified files are still in the git area. Did you commit all the changes?"
   exit 1
 fi
 
-update "${1}"
-git add docs/src/manual.md install denv
-git commit -m "set version to v${1}"
-git tag "v${1}"
-git push --tags
+update "${version}"
+
+# use git diff to print what we changed and then
+# show what other commands would be run given the command options
+if [ "${dry_run}" -eq "1" ]; then
+  git diff docs/src/manual.md install denv
+  if [ "${commit}" -eq "1" ]; then
+    echo git add docs/src/manual.md install denv
+    echo git commit -m "set version to v${1}"
+    echo git tag "v${1}"
+    echo git push --tags
+  fi
+  # undo the changes we made
+  git restore docs/src/manual.md install denv
+  exit 0
+fi
+
+# down here if not in a dry, run keep the applied changes
+if [ "${commit}" -eq "1" ]; then
+  git add docs/src/manual.md install denv
+  git commit -m "set version to v${1}"
+  git tag "v${1}"
+  git push --tags
+fi

--- a/ci/set-version
+++ b/ci/set-version
@@ -74,6 +74,6 @@ fi
 
 update "${1}"
 git add docs/src/manual.md install denv
-git commit -m "set version to ${1}"
-git tag "${1}"
+git commit -m "set version to v${1}"
+git tag "v${1}"
 git push --tags

--- a/ci/set-version
+++ b/ci/set-version
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+set -o nounset
+set -o errexit
+
+# update the version in the source files
+# ARGS
+#  1 - new version X.Y.Z
+update() {
+  # manual source markdown
+  sed -i "s|denv v.*$|denv v${1}|" docs/src/manual.md
+  # install script
+  sed -i "s|^version=v.*$|version=v${1}|" install
+  # denv itself
+  sed -i "s|^denv_version=.*$|denv_version=${1}|" denv
+}
+
+# check if passed version string is a valid version
+# ARGS
+#  1 - version string to test
+validate_version() {
+  expr match "${1}" '^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' > /dev/null
+}
+
+# check if there are any changes the user hasn't commited yet
+check_changes() {
+  # checks for any untracked or modified files
+  git ls-files --other --modified --directory --exclude-standard > /dev/null | sed q1
+}
+
+error() {
+  printf >&2 "\033[1;31mERROR: \033[0m\033[31m%s\033[0m\n" "$*"
+}
+
+inf() {
+  printf "\033[1mINFO: \033[0m%s\n" "$*"
+}
+
+help() {
+  cat<<\HELP
+
+  update the version of denv across all places
+
+ USAGE:
+
+  ./ci/set-version X.Y.Z
+
+ ARGUMENTS
+  X.Y.Z : new version string to use
+
+HELP
+}
+
+if [ "$#" -eq 0 ]; then
+  help
+  exit 0
+fi
+
+if [ "$#" -gt 1 ]; then
+  help
+  error "./ci/set-version requires one and only one argument"
+  exit 1
+fi
+
+if ! validate_version "${1}"; then
+  error "version string '${1}' does not match X.Y.Z"
+  exit 1
+fi
+
+if check_changes; then
+  error "Some untracked or modified files are still in the git area. Did you commit all the changes?"
+  exit 1
+fi
+
+update "${1}"
+git add docs/src/manual.md install denv
+git commit -m "set version to ${1}"
+git tag "${1}"
+git push --tags

--- a/ci/set-version
+++ b/ci/set-version
@@ -19,13 +19,13 @@ update() {
 # ARGS
 #  1 - version string to test
 validate_version() {
-  expr match "${1}" '^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' > /dev/null
+  expr "${1}" : '^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' > /dev/null
 }
 
 # check if there are any changes the user hasn't commited yet
 check_changes() {
   # checks for any untracked or modified files
-  git ls-files --other --modified --directory --exclude-standard > /dev/null | sed q1
+  git ls-files --other --modified --directory --exclude-standard | sed q1 > /dev/null
 }
 
 error() {


### PR DESCRIPTION
Edit the necessary files with `sed` after checking that the `git` working tree is clean and the passed version string is a valid version string. Optionally commit these changes and also have a `--dry-run` option to check that it works properly.