### PR TITLE
use `pwd -P` instead of `$PWD` to avoid symlinks

### DIFF
--- a/denv
+++ b/denv
@@ -285,9 +285,9 @@ _denv_run() {
 ###################################################################################################
 
 _denv_deduce_workspace() {
-  # start from PWD and go up directories until file .denv
+  # start from present working directory and go up directories until find .denv
   # or reach root directory
-  denv_workspace="${PWD}"
+  denv_workspace="$(pwd -P || true)"
   while [ "${denv_workspace}" != "/" ]; do
     if [ -d "${denv_workspace}/.denv" ]; then
       return 0


### PR DESCRIPTION
pwd -P gets the full, non-symlink path of the current directory which we can then walk up to the denv workspace - this should allow us to always mount the workspace directory as its full, real path.

I don't think the other mounts should be `realpath`'d or anything. Since these other paths are provided by the user, I don't like the idea of potentially changing what the mount is under their nose. For this reason, I'm going to only `realpath` the workspace directory which is deduced by `denv` and allow the user to use whichever path they wish for their other mounts (symlink or not).