### PR TITLE
support macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,15 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         runner: [docker, podman, singularity, apptainer]
+        include:
+          - os: macos-latest
+            runner: docker
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3
       - uses: eWaterCycle/setup-singularity@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         runner: [docker, podman, singularity, apptainer]
-        include:
-          - os: macos-latest
-            runner: docker
+#        include:
+#          - os: macos-latest
+#           runner: docker
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
           apptainer-version: 1.1.9
       - uses: douglascamata/setup-docker-macos-action@v1-alpha
         if: ${{matrix.os == 'macos-latest'}}
+      - name: enable debug mode if requested
+        if: ${{runner.debug == '1'}}
+        run: echo "DENV_DEBUG=1" >> "$GITHUB_ENV"
       - name: Install
         run: sudo ./install
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
         if: ${{matrix.runner == 'apptainer'}}
         with:
           apptainer-version: 1.1.9
+      - uses: douglascamata/setup-docker-macos-action@v1-alpha
+        if: ${{matrix.os == 'macos-latest'}}
       - name: Install
         run: sudo ./install
       - name: Test

--- a/denv
+++ b/denv
@@ -23,16 +23,12 @@ denv_version=0.2.1
 set -o errexit
 set -o nounset
 
-if ! hash realpath &> /dev/null; then
-  realpath() {
-    d="$(dirname "$1")"
-    d="$(cd "${d}" && pwd -P)"
-    echo "${d}/$(basename "$1")"
-  }
-fi
-
 # deduce full path to our executable so we can locate the entrypoint executable
-denv_fullpath="$(realpath "$0")"
+# we need to write our own function to deduce the full path to denv
+# because MacOS does not have the 'realpath' function out of the box.
+denv_install_dir="$(dirname "$0")"
+denv_install_dir="$(cd "${denv_install_dir}" && pwd -P)"
+denv_fullpath="${denv_install_dir}/denv"
 # deduce full path to entrypoint executable
 denv_entrypoint="$(dirname "${denv_fullpath}" || true)/_denv_entrypoint"
 

--- a/denv
+++ b/denv
@@ -23,8 +23,16 @@ denv_version=0.2.1
 set -o errexit
 set -o nounset
 
+if ! hash realpath; then
+  realpath() {
+    d="$(dirname "$1")"
+    d="$(cd "${d}" && pwd -P)"
+    echo "${d}/$(basename "$1")"
+  }
+fi
+
 # deduce full path to our executable so we can locate the entrypoint executable
-denv_fullpath="$(realpath "$0" || true)"
+denv_fullpath="$(realpath "$0")"
 # deduce full path to entrypoint executable
 denv_entrypoint="$(dirname "${denv_fullpath}" || true)/_denv_entrypoint"
 

--- a/denv
+++ b/denv
@@ -202,7 +202,7 @@ _denv_run() {
   # we will be running now and not writing the config
   # so we can update the denv_mounts list
   [ -d /tmp/.X11-unix ] && denv_mounts="${denv_mounts} /tmp/.X11-unix"
-  denv_mounts="${denv_mounts} ${denv_entrypoint}"
+  denv_mounts="${denv_mounts} $(dirname "${denv_entrypoint}")"
   case "${denv_runner}" in
     docker|podman)
       interactive=""

--- a/denv
+++ b/denv
@@ -591,17 +591,17 @@ _denv_init() {
   if [ -d "${denv_workspace}/.denv" ];then
     if [ "${force}" = "0" ]; then
       _denv_info "overwriting previous denv workspace"
-      rm -rf "${denv_workspace}/.denv"
     elif [ -n "${DENV_NOPROMPT+x}" ]; then
-      _denv_error "denv prompt disabled but unwilling to delete a denv without user input."
+      _denv_error "denv prompt disabled but unwilling to overwrite a denv without user input."
       return 1
     else
       printf "\033[1mThis workspace already has a denv. Would you like to overwrite it?\033[0m [Y/n] "
       read -r ans
       case "${ans}" in
         Y|y)
-          # delete old denv and continue below
-          rm -rf "${denv_workspace}/.denv"
+          # pretend like there isn't a .denv there
+          # we will overwrite .denv/config and .denv/.gitignore
+          # in this function
           ;;
         *)
           _denv_info "Exiting without modifying..."
@@ -609,6 +609,8 @@ _denv_init() {
           ;;
       esac
     fi
+  else
+    mkdir "${denv_workspace}/.denv"
   fi
 
   # set the default denv name to the workspace directory name
@@ -619,7 +621,6 @@ _denv_init() {
   denv_image="${image}"
   denv_shell="/bin/bash -i"
   denv_mounts=""
-  mkdir "${denv_workspace}/.denv"
   _denv_write_config
   if [ "${gitignore}" = "1" ]; then
     _denv_info "Writing a gitignore for the .denv directory."

--- a/denv
+++ b/denv
@@ -23,7 +23,7 @@ denv_version=0.2.1
 set -o errexit
 set -o nounset
 
-if ! hash realpath; then
+if ! hash realpath &> /dev/null; then
   realpath() {
     d="$(dirname "$1")"
     d="$(cd "${d}" && pwd -P)"

--- a/install
+++ b/install
@@ -157,12 +157,12 @@ if [ -e "${curr_dir}/denv" ]; then
     ${copy} "${PWD}/_denv_entrypoint" "${dest_path}"
   else
     copy="install -m 0644"
-    if ! install -m 0755 denv "${dest_path}"; then
+    if ! install -m 0775 denv "${dest_path}"; then
       _denv_error "Copying to ${dest_path} failed." \
         "Do you have permission to write there?"
       exit 1
     fi
-    install -m 0755 _denv_entrypoint "${dest_path}"
+    install -m 0775 _denv_entrypoint "${dest_path}"
   fi
   if [ -e "man" ]; then
     for file in "${PWD}"/man/man1/*; do
@@ -215,12 +215,12 @@ else
 
   # deploy
   copy="install -m 0644"
-  if ! install -m 0755 denv "${dest_path}"; then
+  if ! install -m 0775 denv "${dest_path}"; then
     _denv_error "Copying to ${dest_path} failed." \
       "Do you have permission to write there?"
     exit 1
   fi
-  install -m 0755 _denv_entrypoint "${dest_path}"
+  install -m 0775 _denv_entrypoint "${dest_path}"
   if [ -e "man" ]; then
     for file in "${PWD}"/man/man1/*; do
       ${copy} "${file}" "${man_dest_path}"

--- a/install
+++ b/install
@@ -147,30 +147,30 @@ fi
 # if files are available here, install files in dest directory
 if [ -e "${curr_dir}/denv" ]; then
   if [ "${devel}" -ne 0 ]; then
-    copy="ln -sf -t"
-    if ! ${copy} "${dest_path}" "${PWD}/denv"; then
+    copy="ln -sf"
+    if ! ${copy} "${PWD}/denv" "${dest_path}"; then
       _denv_error "Copying to ${dest_path} failed." \
         "Do you have permission to write there?"
       exit 1
     fi
-    ${copy} "${dest_path}" "${PWD}/_denv_entrypoint"
+    ${copy} "${PWD}/_denv_entrypoint" "${dest_path}"
   else
-    copy="install -D -m 0644 -t"
-    if ! install -D -m 0755 -t "${dest_path}" denv; then
+    copy="install -m 0644"
+    if ! install -m 0755 denv "${dest_path}"; then
       _denv_error "Copying to ${dest_path} failed." \
         "Do you have permission to write there?"
       exit 1
     fi
-    install -D -m 0755 -t "${dest_path}" _denv_entrypoint
+    install -m 0755 _denv_entrypoint "${dest_path}"
   fi
   if [ -e "man" ]; then
     for file in "${PWD}"/man/man1/*; do
-      ${copy} "${man_dest_path}" "${file}"
+      ${copy} "${file}" "${man_dest_path}"
     done
   fi
   if [ -e "completions" ]; then
     for file in "${PWD}"/completions/*; do
-      ${copy} "${completion_dest_path}" "${file}"
+      ${copy} "${file}" "${completion_dest_path}"
     done
   fi
 else
@@ -213,21 +213,21 @@ else
   cd "denv-$(echo "${release_name}" | sed 's|.tar.gz||' || true)"
 
   # deploy
-  copy="install -D -m 0644 -t"
-  if ! install -D -m 0755 -t "${dest_path}" denv; then
+  copy="install -m 0644"
+  if ! install -m 0755 denv "${dest_path}"; then
     _denv_error "Copying to ${dest_path} failed." \
       "Do you have permission to write there?"
     exit 1
   fi
-  install -D -m 0755 -t "${dest_path}" _denv_entrypoint
+  install -m 0755 _denv_entrypoint "${dest_path}"
   if [ -e "man" ]; then
     for file in "${PWD}"/man/man1/*; do
-      ${copy} "${man_dest_path}" "${file}"
+      ${copy} "${file}" "${man_dest_path}"
     done
   fi
   if [ -e "completions" ]; then
     for file in "${PWD}"/completions/*; do
-      ${copy} "${completion_dest_path}" "${file}"
+      ${copy} "${file}" "${completion_dest_path}"
     done
   fi
 

--- a/install
+++ b/install
@@ -119,9 +119,11 @@ if  [ -z "${prefix}" ]; then
   fi
 fi
 
-if [ ! -w "${prefix}" ]; then
-  _denv_error "Cannot write into ${prefix}, permission denied"
-  exit 1
+if [ ! -d "${prefix}" ]; then
+  if ! mkdir -p "${prefix}"; then
+    _denv_error "Cannot write into ${prefix}, permission denied"
+    exit 1
+  fi
 fi
 
 completion_dest_path="${prefix}/share/bash-completion/completions/"

--- a/install
+++ b/install
@@ -20,7 +20,10 @@
 # POSIX
 set -o errexit
 set -o nounset
-set -o xtrace
+
+if [ -n "${DENV_DEBUG+x}" ]; then
+  set -o xtrace
+fi
 
 _denv_info() {
   printf "\033[32;1m INFO: \033[0m\033[32m%s\n" "$1"

--- a/install
+++ b/install
@@ -118,6 +118,12 @@ if  [ -z "${prefix}" ]; then
     prefix="${HOME}/.local"
   fi
 fi
+
+if [ ! -w "${prefix}" ]; then
+  _denv_error "Cannot write into ${prefix}, permission denied"
+  exit 1
+fi
+
 completion_dest_path="${prefix}/share/bash-completion/completions/"
 dest_path="${prefix}/bin"
 man_dest_path="${prefix}/share/man/man1"
@@ -130,9 +136,8 @@ cd "${curr_dir}" || exit 1
 if [ ! -d "${dest_path}" ]; then
   mkdir -p "${dest_path}"
 fi
-if [ ! -w "${man_dest_path}" ]; then
-  _denv_error "Cannot write into ${man_dest_path}, permission denied"
-  exit 1
+if [ ! -d "${man_dest_path}" ]; then
+  mkdir -p "${man_dest_path}"
 fi
 if [ ! -d "${completion_dest_path}" ]; then
   mkdir -p "${completion_dest_path}"

--- a/install
+++ b/install
@@ -96,7 +96,8 @@ while [ "$#" -gt 0 ]; do
       ;;
     -p | --prefix)
       if [ -n "$2" ]; then
-        prefix="$2"
+        [ -d "$2" ] || mkdir -p "$2"
+        prefix="$(cd "$2" && pwd -P)"
         shift
         shift
       fi
@@ -119,11 +120,9 @@ if  [ -z "${prefix}" ]; then
   fi
 fi
 
-if [ ! -d "${prefix}" ]; then
-  if ! mkdir -p "${prefix}"; then
-    _denv_error "Cannot write into ${prefix}, permission denied"
-    exit 1
-  fi
+if [ ! -w "${prefix}" ]; then
+  _denv_error "Cannot write into ${prefix}, permission denied"
+  exit 1
 fi
 
 completion_dest_path="${prefix}/share/bash-completion/completions/"

--- a/install
+++ b/install
@@ -20,6 +20,7 @@
 # POSIX
 set -o errexit
 set -o nounset
+set -o xtrace
 
 _denv_info() {
   printf "\033[32;1m INFO: \033[0m\033[32m%s\n" "$1"
@@ -247,7 +248,22 @@ if [ "${simple}" -eq "0" ]; then
   ln -sf denv '\'
 fi
 
-_denv_info "Successfully installed denv to ${dest_path}"
+# double check that the installation is functional
+unset DENV_INSTALL_FAILURE
+for executable in "denv" "_denv_entrypoint"; do
+  if [ -x "${dest_path}/${executable}" ] && [ -f "${dest_path}/${executable}" ]; then
+    continue
+  fi
+  _denv_error "'${executable}' does not exist as an executable file at '${dest_path}/${executable}'"
+  DENV_INSTALL_FAILURE=1
+done
+
+if [ -z "${DENV_INSTALL_FAILURE+x}" ]; then
+  _denv_info "Successfully installed denv to ${dest_path}"
+else
+  _denv_error "Installation corrupted!"
+fi
+
 case "${PATH}" in
   *"${dest_path}"*)
     _denv_info "Found ${dest_path} in PATH, you're all set!"


### PR DESCRIPTION
This will hopefully then allow users to install even if the man page sub-directories do not already exist in the install prefix location.

After updating the install script and adding MacOS+docker to the CI testing, I discovered some other things that needed to be patched in order to support MacOS. The branch used for this PR will resolve #39 but also expand slightly to include supporting MacOS in `denv` itself (hopefully, need to find a way to test more quickly than in GitHub CI).