### PR TITLE
revert directory-based mounting of entrypoint

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -79,6 +79,9 @@ check_pass denv config print
 check_fail denv false
 # make sure name setting works
 check_equal 'denv printenv DENV_NAME' "basename ${PWD}"
+# make sure we can set environment variables for non-interactive denv
+export MY_ENV_VAR=yes
+check_equal 'denv printenv MY_ENV_VAR' 'echo yes'
 # can force re-init of denv
 check_pass denv init ubuntu:22.04 --force --name newname
 # make sure update was applied

--- a/denv
+++ b/denv
@@ -202,7 +202,7 @@ _denv_run() {
   # we will be running now and not writing the config
   # so we can update the denv_mounts list
   [ -d /tmp/.X11-unix ] && denv_mounts="${denv_mounts} /tmp/.X11-unix"
-  denv_mounts="${denv_mounts} $(dirname "${denv_entrypoint}")"
+  denv_mounts="${denv_mounts} ${denv_entrypoint}"
   case "${denv_runner}" in
     docker|podman)
       interactive=""


### PR DESCRIPTION
if the parent of the directory of the entrypoint is not mounted/created
within the container image, then docker responds with an error about how
the target directory does not exist. We can avoid this error by mounting
the single file which docker recognizes as a "symlink"-style mount and
can ignore the fact that its parent directories may not exist

```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/home/tom/.local/bin/_denv_entrypoint": stat /home/tom/.local/bin/_denv_entrypoint: no such file or directory: unknown.
```