### PR TITLE
use `sh -lc` to run the command in denv

### DIFF
--- a/_denv_entrypoint
+++ b/_denv_entrypoint
@@ -107,5 +107,4 @@ if [ ! -f "${HOME}/.denv/skel-init" ]; then
 fi
 
 # intentionally allowing command line args to re-split into a command
-# shellcheck disable=SC2068
-$@
+sh -lc "$*"

--- a/_denv_entrypoint
+++ b/_denv_entrypoint
@@ -106,5 +106,6 @@ if [ ! -f "${HOME}/.denv/skel-init" ]; then
   touch "${HOME}/.denv/skel-init"
 fi
 
-# intentionally allowing command line args to re-split into a command
+# use a login shell to give users an opportunity to update env variables
+# via the ~/.profile file if desired
 sh -lc "$*"

--- a/ci/test
+++ b/ci/test
@@ -93,6 +93,13 @@ check_equal 'denv printenv DENV_NAME' 'echo newname'
 if [ "${DENV_RUNNER}" != "podman" ]; then
   check_equal 'whoami' 'denv whoami'
 fi
+# "install" a simple executable and make sure it is available non-interactively
+mkdir -p .local/bin
+cat > .local/bin/hello <<\WORLD
+echo world
+WORLD
+chmod +x .local/bin/hello
+check_equal 'denv hello' './.local/bin/hello'
 # make sure files written from denv are owned by user outside denv
 check_pass denv touch file-from-denv
 check_equal 'stat -c %u file-from-denv' "id -u ${USER}"

--- a/docs/src/tune.md
+++ b/docs/src/tune.md
@@ -57,6 +57,18 @@ run() {
 }
 ```
 
+### `sh` and `.profile`
+Inside the denv, we use `sh -lc` to run the command provided to `denv`.
+The `c` flag is used to specify the command being run, but of more importance
+to us is the `l` flag which forces `sh` to be a _login_ shell.
+
+For our purposes, this means that various initialization files will be sourced
+while launched `sh` and before the command is run, specifically, one of the files
+that can be used is at `~/.profile` (or `<workspace>/.profile` outside the denv).
+Updating this file with changes to `*PATH` variables (like `PATH`, `LD_LIBRARY_PATH`,
+and `PYTHONPATH`) can be helpful so that executables can be run interactively
+(i.e. `denv` then `my-executable`) and non-interactively (i.e. `denv my-executable`).
+
 ## extra mounts
 By default, `denv` only allows the container to view the files within
 the workspace[^1]. This works for many projects; however,

--- a/docs/src/tune.md
+++ b/docs/src/tune.md
@@ -63,7 +63,7 @@ The `c` flag is used to specify the command being run, but of more importance
 to us is the `l` flag which forces `sh` to be a _login_ shell.
 
 For our purposes, this means that various initialization files will be sourced
-while launched `sh` and before the command is run, specifically, one of the files
+while launching `sh` and before the command is run, specifically, one of the files
 that can be used is at `~/.profile` (or `<workspace>/.profile` outside the denv).
 Updating this file with changes to `*PATH` variables (like `PATH`, `LD_LIBRARY_PATH`,
 and `PYTHONPATH`) can be helpful so that executables can be run interactively


### PR DESCRIPTION
This has the benefit of spawning a login shell for us, sourcing `~/.profile` within the container and thus giving the user an opportunity to update `PATH` variables inside the container before the executable is run.