### PR TITLE
enhance configuration of environment variables

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -89,15 +89,20 @@ check_fail denv false
 # make sure name setting works
 check_equal 'denv printenv DENV_NAME' "basename ${PWD}"
 # make sure we can set environment variables for non-interactive denv
-export MY_ENV_VAR=yes
-check_equal 'denv printenv MY_ENV_VAR' 'echo yes'
-check_pass denv config env copy MY_VAR
-check_fail 'denv printenv MY_ENV_VAR'
-check_fail 'denv printenv MY_VAR'
-export MY_VAR=yes
-check_equal 'denv printenv MY_VAR' 'echo yes'
-check_pass denv config env set MY_VAR=no
-check_equal 'denv printenv MY_VAR' 'echo no'
+export foo=bar
+check_equal 'denv printenv foo' 'printenv foo'
+check_pass denv config env all no
+check_pass 'printenv foo'
+check_fail 'denv printenv foo'
+check_pass denv config env copy baz myfoo=mybar
+check_fail 'printenv myfoo'
+check_equal 'denv printenv myfoo' 'echo mybar'
+check_fail 'denv printenv baz'
+export baz=hooray
+check_pass 'printenv baz'
+check_equal 'denv printenv baz' 'printenv baz'
+export myfoo='host-value'
+check_equal 'denv printenv myfoo' 'echo mybar'
 # can force re-init of denv
 check_pass denv init ubuntu:22.04 --force --name newname
 # make sure update was applied

--- a/ci/test
+++ b/ci/test
@@ -91,6 +91,13 @@ check_equal 'denv printenv DENV_NAME' "basename ${PWD}"
 # make sure we can set environment variables for non-interactive denv
 export MY_ENV_VAR=yes
 check_equal 'denv printenv MY_ENV_VAR' 'echo yes'
+check_pass denv config env copy MY_VAR
+check_fail 'denv printenv MY_ENV_VAR'
+check_fail 'denv printenv MY_VAR'
+export MY_VAR=yes
+check_equal 'denv printenv MY_VAR' 'echo yes'
+check_pass denv config env set MY_VAR=no
+check_equal 'denv printenv MY_VAR' 'echo no'
 # can force re-init of denv
 check_pass denv init ubuntu:22.04 --force --name newname
 # make sure update was applied

--- a/ci/test
+++ b/ci/test
@@ -11,7 +11,14 @@ set -o nounset
 # disable denv prompt
 export DENV_NOPROMPT=1
 
-workspace=$(mktemp -d || true)
+if [ -z "${1:-}" ]; then
+  workspace=$(mktemp -d || true)
+  delete=1
+else
+  workspace="${1}"
+  mkdir "${workspace}"
+  workspace="$(cd "${workspace}" && pwd -P)"
+fi
 
 inf() {
   printf "\033[1mINFO: \033[0m%s\n" "$*"
@@ -19,8 +26,10 @@ inf() {
 
 fail() {
   printf >&2 "\033[1;31mFAIL: \033[0m\033[31m%s\033[0m\n" "$*"
-  cd
-  rm -r "${workspace}"
+  if [ -n "${delete:+x}" ]; then
+    cd
+    rm -r "${workspace}"
+  fi
   exit 1
 }
 
@@ -118,5 +127,7 @@ check_pass denv config image ubuntu:18.04
 # and check
 check_pass denv grep -q '18.04' /etc/os-release
 
-cd
-rm -r "${workspace}"
+if [ -n "${delete:+x}" ]; then
+  cd
+  rm -r "${workspace}"
+fi

--- a/completions/denv
+++ b/completions/denv
@@ -19,7 +19,7 @@ __denv() {
         COMPREPLY=()
         ;;
       config)
-        COMPREPLY=($(compgen -W "help print image mounts shell" "$curr_word"))
+        COMPREPLY=($(compgen -W "help print image mounts shell env" "$curr_word"))
         ;;
       *)
         # re-enable normal tab completion for everything else
@@ -36,6 +36,30 @@ __denv() {
       mounts)
         # directory tab completion
         COMPREPLY=($(compgen -d -- "$curr_word"))
+        ;;
+      env)
+        if [[ "${COMP_CWORD}" = "3" ]]; then
+          COMPREPLY=($(compgen -W "help print copy all reset" "$curr_word"))
+        elif [[ "${COMP_CWORD}" = "4" ]]; then
+          case "${COMP_WORDS[3]}" in
+            help|print|reset)
+              COMPREPLY=()
+              ;;
+            all)
+              COMPREPLY=($(compgen -W "yes no" "$curr_word"))
+              ;;
+            copy)
+              copyable=$(printenv \
+                          | grep -Ev ' |`|"|\$' \
+                          | grep -Ev '^(DENV|HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG|_)' \
+                          | sed 's|=.*||g')
+              COMPREPLY=($(compgen -W "${copyable}" "$curr_word"))
+              ;;
+            *)
+              COMPREPLY=()
+              ;;
+          esac
+        fi
         ;;
       *)
         # no tab completion again

--- a/denv
+++ b/denv
@@ -313,7 +313,6 @@ _denv_deduce_workspace() {
 }
 
 _denv_bad_env_var_name_regex="^(HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG_.*_DIRS|^_)"
-_denv_bad_env_value_regex=' |"|`|\$'
 
 # load the denv config from the input workspace
 # Arguments
@@ -353,8 +352,8 @@ _denv_load_config() {
 
   # deduce environment variables from configuration
   # copy-able environment variables, code copied from distrobox
-  copyable_environment="$(printenv | grep '=' | grep -Ev "'${_denv_bad_env_value_regex}'" | grep -Ev "${_denv_bad_env_var_name_regex}")"
-  if [ "${denv_env_var_copy_all}" -eq "1" ]; then
+  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev "${_denv_bad_env_var_name_regex}")"
+  if [ "${denv_env_var_copy_all}" = "true" ]; then
     # deduce env variables, copied from distrobox
     denv_environment="${copyable_environment}"
   else
@@ -587,8 +586,8 @@ _denv_config_env() {
         _denv_error "The passed variables named above are special and should not be used in the denv."
         return 1
       fi
-      if echo "$*" | grep -E "'${_denv_bad_env_value_regex}'"; then
-        _denv_error "Values cannot use special characters (space, slash, tick, etc...)"
+      if echo "$*" | grep -E ' |"|`|\$'; then
+        _denv_error "Values cannot use special characters (space ' ', quote '\"', tick '\`', dollar-sign '$')"
         return 1
       fi
       # TODO: validate passed varialbe names and values

--- a/denv
+++ b/denv
@@ -95,6 +95,21 @@ _denv_mounts_to_args() {
   echo "${mount_args}"
 }
 
+# conver the environment variable related configuration parameters
+# to a string list of arguments for the container runner
+# Arguments
+#  1 - option name to prefix each environment variable with
+#  denv_environment - space-separated key=value pairs to put into the denv
+# Outputs
+#  list of env-var-related arugments to provide to run command
+_denv_environment_to_args() {
+  env_args=""
+  for ev in ${denv_environment}; do
+    env_args="${1} ${ev} ${env_args}"
+  done
+  echo "${env_args}"
+}
+
 ###################################################################################################
 # container runner interface
 #
@@ -222,25 +237,7 @@ _denv_run() {
       else
         mounts="${mounts} --volume ${denv_workspace}:${denv_workspace}"
       fi
-      environment="--env DENV_NAME=${denv_name}
-      --env DENV_RUNNER=${denv_runner}
-      --env DENV_IMAGE=${denv_image}
-      --env HOME=${denv_workspace}"
-      # deduce env variables, copied from distrobox
-      set +o xtrace # disable trace for this snippet
-      for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' | \
-        grep -Ev '^(HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG_.*_DIRS|^_)'); do
-        # environment filtered to ignore strange variables that are multiline or contain spaces in their values
-        # we also need to exclude important variables that we are defining special for the conatiner like HOME,
-        # HOSTNAME, and PATH
-        environment="--env ${i} ${environment}"
-      done
-      if [ -n "${DENV_DEBUG+x}" ]; then
-        # renable trace
-        set -o xtrace
-        # add to the environment
-        environment="${environment} --env DENV_DEBUG=${DENV_DEBUG}"
-      fi
+      environment="$(_denv_environment_to_args --env)"
       userspec="$(id -u "${USER}"):$(id -g "${USER}")"
       # until podman makes a release v4.6.0 with idmap
       # the simplest solution is to just have the in-container user be root
@@ -267,13 +264,13 @@ _denv_run() {
       _denv_config_checked_pull DO_NOT_PROMPT_USER
       mounts="$(_denv_mounts_to_args "--bind")"
       sif_file="${denv_image_cache}/$(_denv_image_to_filename).sif"
+      environment="$(_denv_environment_to_args "--env")"
       # shellcheck disable=SC2086
       PWD=$(pwd -P) ${denv_runner} exec \
         --hostname "${_hostname}" \
         --home "${denv_workspace}" \
-        --env DENV_NAME="${denv_name}" \
-        --env DENV_RUNNER=${denv_runner} \
-        --env DENV_IMAGE=${denv_image} \
+        --cleanenv \
+        ${environment} \
         ${mounts} \
         "${sif_file}" \
         "${denv_entrypoint}" \
@@ -350,6 +347,40 @@ _denv_load_config() {
     denv_runner="norunner"
   fi
   _denv_info "using ${denv_runner} as runner"
+
+  # deduce environment variables from configuration
+  #set +o xtrace $ disable tracing even in DEBUG for this snippet since its alot
+  # copy-able environment variables, copied from distrobox
+  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev '^(HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG_.*_DIRS|^_)')"
+  if [ "${denv_env_var_copy_all}" -eq "1" ]; then
+    # deduce env variables, copied from distrobox
+    denv_environment="${copyable_environment}"
+  else
+    match_any_pattern="^($(echo "${denv_env_var_copy}" | sed 's/ /|/g'))="
+    denv_environment="$(echo "${copyable_environment}" | grep -E "${match_any_pattern}" || true)"
+  fi
+
+  denv_environment="${denv_environment} ${denv_env_var_set}"
+
+  # always add necessary environment variables
+  denv_environment="${denv_environment} DENV_NAME=${denv_name}"
+  denv_environment="${denv_environment} DENV_RUNNER=${denv_runner}"
+  denv_environment="${denv_environment} DENV_IMAGE=${denv_image}"
+  denv_environment="${denv_environment} HOME=${denv_workspace}"
+
+  if [ -n "${DENV_DEBUG+x}" ]; then
+    # renable trace
+    set -o xtrace
+    # add to the environment
+    denv_environment="${denv_environment} DENV_DEBUG=${DENV_DEBUG}"
+  fi
+
+  # env sifts out the unique variable names for us and uses the last value set
+  # this is the behavior we want since we add the `set` variables _after_
+  # the `copy` variables allowing the user to overwrite any host variables
+  # disabling double-quote warning so that we can re-split the space-separated list
+  # shellcheck disable=SC2086
+  denv_environment="$(env -i ${denv_environment})"
 }
 
 # write the current config to the file
@@ -363,12 +394,18 @@ _denv_write_config() {
     echo "denv_image=\"${denv_image}\"";
     echo "denv_shell=\"${denv_shell}\"";
     echo "denv_mounts=\"${denv_mounts}\"";
+    echo "denv_env_var_copy_all=${denv_env_var_copy_all}";
+    echo "denv_env_var_copy=\"${denv_env_var_copy}\"";
+    echo "denv_env_var_set=\"${denv_env_var_set}\"";
   } > "${config}"
 }
 
 # print the current denv config
 # Arguments
 #  all denv_* env vars
+#  1 - optional, if provided then print deduced env vars
+#      if we aren't copying the host env vars, then we will
+#      print them as well, expecting the list to be shorter
 _denv_config_print() {
   printf "%s=\"%s\"\n" denv_workspace "${denv_workspace}"
   printf "%s=\"%s\"\n" denv_name "${denv_name}"
@@ -376,6 +413,11 @@ _denv_config_print() {
   printf "%s=\"%s\"\n" denv_mounts "${denv_mounts}"
   printf "%s=\"%s\"\n" denv_shell "${denv_shell}"
   _denv_runner
+  if [ ! "${denv_env_var_copy_all}" -eq "1" ] || [ -n "${1:-}" ]; then
+    # disabling double-quote warning so that we can re-split the space-separated list
+    # shellcheck disable=SC2086
+    printf "%s\n" ${denv_environment}
+  fi
 }
 
 # pull down the ${denv_image} if it doesn't exist
@@ -455,6 +497,116 @@ _denv_config_mounts() {
   done
 }
 
+# configure environment variables for within the denv
+# Arguments
+#  1 - {all,copy,set}
+# Outputs
+#  updates the denv_env_var* config variables appropriately
+_denv_config_env_help() {
+  cat <<\HELP
+
+  denv config env [help|-h|--help]
+  denv config env all {yes|no}
+  denv config env copy VAR0 [VAR1 VAR2 ...]
+  denv config env set VAR0=VAL0 [VAR1=VAL1 ...]
+  denv config env reset {all|copy|set}
+
+ COMMANDS
+  help    print this help and exit
+  all     configure denv to copy "all" copy-able environment variables
+          into the denv, this means any variables set to be copied manually
+          will be ignored
+  copy    configure denv to copy specific environment variables (the VAR arguments)
+          into the denv. This disables the copy all feature as well.
+  set     Set specific environment variables as KEY=VALUE pairs to be defined within
+          the denv.
+  reset   reset the various environment variable lists.
+          all  - reset to the copy all state *AND* clear the copy and set lists
+          copy - clear the copy list
+          set  - clear the set list
+
+HELP
+}
+_denv_config_env() {
+  if [ -z "${1}" ]; then
+    _denv_config_env_help
+    return 1
+  fi
+  case "$1" in
+    help|-h|--help)
+      _denv_config_env_help
+      return 0
+      ;;
+    all)
+      shift
+      if [ "$#" -eq "0" ]; then
+        # default with no arguments is yes
+        denv_env_var_copy_all=1
+        return 0;
+      fi
+      case "$1" in
+        no|n)
+          denv_env_var_copy_all=0
+          ;;
+        yes|y)
+          denv_env_var_copy_all=1
+          ;;
+        *)
+          _denv_error "'$1' is not 'yes' or no'"
+          return 1;
+          ;;
+      esac
+      ;;
+    copy)
+      denv_env_var_copy_all=0
+      shift
+      # TODO: validate passed variable names
+      if [ -z "${denv_env_var_copy}" ]; then
+        denv_env_var_copy="$*"
+      else
+        denv_env_var_copy="${denv_env_var_copy} $*"
+      fi
+      ;;
+    set)
+      shift
+      # TODO: validate passed varialbe names and values
+      if [ -z "${denv_env_var_set}" ]; then
+        denv_env_var_set="$*"
+      else
+        denv_env_var_set="${denv_env_var_set} $*"
+      fi
+      ;;
+    reset)
+      shift
+      if [ -z "${1}" ]; then
+        _denv_config_env_help
+        _denv_error "'denv config env reset' requires an argument."
+        return 1;
+      fi
+      case "$1" in
+        all)
+          denv_env_var_copy_all=1
+          denv_env_var_copy=""
+          denv_env_var_set=""
+          ;;
+        copy)
+          denv_env_var_copy=""
+          ;;
+        set)
+          denv_env_var_set=""
+          ;;
+        *)
+          _denv_error "'$1' is not a recognized keyword for 'denv config env reset'"
+          return 1
+      esac
+      ;;
+    *)
+      _denv_error "'$1' is not a recognized keyword 'all', 'copy', or 'set'"
+      return 1
+      ;;
+  esac
+}
+
 # config some config variable
 # Arguments
 #  1 - varible to config
@@ -463,14 +615,16 @@ _denv_config_help() {
   cat <<\HELP
 
   denv config [help|-h|--help]
-  denv config print
+  denv config print [include-env]
   denv config image [pull|IMAGE]
   denv config mounts DIR0 [DIR1 DIR2 ...]
   denv config shell SHELL
+  denv config env [args...]
 
  COMMANDS
   help    print this help and exit
   print   print the deduced config for viewing
+          if an argument is provided, then show the environment variables as well
   image   set the image you wish to use
           the special keyword 'pull' can be used to
           not change the image being used but to re-download
@@ -478,6 +632,9 @@ _denv_config_help() {
   mounts  add one or more directories to be mounted to the denv
   shell   change which program is executed when opening
           the denv without any arguments
+  env     configure which environment variables are put
+          into the container environment
+          `denv config env help` for more detail
 
 HELP
 }
@@ -490,9 +647,9 @@ _denv_config() {
     print)
       _denv_load_config
       cmd="_denv_config_${1}"
-      ${cmd}
+      ${cmd} "${2:-}"
       ;;
-    image|shell|mounts)
+    image|shell|mounts|env)
       _denv_load_config
       cmd="_denv_config_${1}"
       if [ "$#" -eq "1" ]; then
@@ -621,6 +778,9 @@ _denv_init() {
   denv_image="${image}"
   denv_shell="/bin/bash -i"
   denv_mounts=""
+  denv_env_var_copy_all=1
+  denv_env_var_copy=""
+  denv_env_var_set=""
   _denv_write_config
   if [ "${gitignore}" = "1" ]; then
     _denv_info "Writing a gitignore for the .denv directory."

--- a/denv
+++ b/denv
@@ -414,9 +414,7 @@ _denv_config_print() {
   printf "%s=\"%s\"\n" denv_shell "${denv_shell}"
   _denv_runner
   if [ ! "${denv_env_var_copy_all}" -eq "1" ] || [ -n "${1:-}" ]; then
-    # disabling double-quote warning so that we can re-split the space-separated list
-    # shellcheck disable=SC2086
-    printf "%s\n" ${denv_environment}
+    _denv_config_env print
   fi
 }
 
@@ -506,6 +504,7 @@ _denv_config_env_help() {
   cat <<\HELP
 
   denv config env [help|-h|--help]
+  denv config env print
   denv config env all {yes|no}
   denv config env copy VAR0 [VAR1 VAR2 ...]
   denv config env set VAR0=VAL0 [VAR1=VAL1 ...]
@@ -513,6 +512,7 @@ _denv_config_env_help() {
 
  COMMANDS
   help    print this help and exit
+  print   print the deduced environment variables that will be put into the container
   all     configure denv to copy "all" copy-able environment variables
           into the denv, this means any variables set to be copied manually
           will be ignored
@@ -536,6 +536,11 @@ _denv_config_env() {
     help|-h|--help)
       _denv_config_env_help
       return 0
+      ;;
+    print)
+      # disabling double-quote warning so that we can re-split the space-separated list
+      # shellcheck disable=SC2086
+      printf "%s\n" ${denv_environment}
       ;;
     all)
       shift

--- a/denv
+++ b/denv
@@ -393,7 +393,7 @@ _denv_write_config() {
     echo "denv_image=\"${denv_image}\"";
     echo "denv_shell=\"${denv_shell}\"";
     echo "denv_mounts=\"${denv_mounts}\"";
-    echo "denv_env_var_copy_all=${denv_env_var_copy_all}";
+    echo "denv_env_var_copy_all=\"${denv_env_var_copy_all}\"";
     echo "denv_env_var_copy=\"${denv_env_var_copy}\"";
     echo "denv_env_var_set=\"${denv_env_var_set}\"";
   } > "${config}"
@@ -412,7 +412,7 @@ _denv_config_print() {
   printf "%s=\"%s\"\n" denv_mounts "${denv_mounts}"
   printf "%s=\"%s\"\n" denv_shell "${denv_shell}"
   _denv_runner
-  if [ ! "${denv_env_var_copy_all}" -eq "1" ] || [ -n "${1:-}" ]; then
+  if [ ! "${denv_env_var_copy_all}" = "true" ] || [ -n "${1:-}" ]; then
     _denv_config_env print
   fi
 }
@@ -545,15 +545,15 @@ _denv_config_env() {
       shift
       if [ "$#" -eq "0" ]; then
         # default with no arguments is yes
-        denv_env_var_copy_all=1
+        denv_env_var_copy_all="true"
         return 0;
       fi
       case "$1" in
         no|n)
-          denv_env_var_copy_all=0
+          denv_env_var_copy_all="false"
           ;;
         yes|y)
-          denv_env_var_copy_all=1
+          denv_env_var_copy_all="true"
           ;;
         *)
           _denv_error "'$1' is not 'yes' or no'"
@@ -562,7 +562,7 @@ _denv_config_env() {
       esac
       ;;
     copy)
-      denv_env_var_copy_all=0
+      denv_env_var_copy_all="false"
       shift
       if echo "$*" | grep -E "${_denv_bad_env_var_name_regex}"; then
         _denv_error "The passed variables named above are special and should not be used in the denv."
@@ -606,7 +606,7 @@ _denv_config_env() {
       fi
       case "$1" in
         all)
-          denv_env_var_copy_all=1
+          denv_env_var_copy_all="true"
           denv_env_var_copy=""
           denv_env_var_set=""
           ;;
@@ -799,7 +799,7 @@ _denv_init() {
   denv_image="${image}"
   denv_shell="/bin/bash -i"
   denv_mounts=""
-  denv_env_var_copy_all=1
+  denv_env_var_copy_all="true"
   denv_env_var_copy=""
   denv_env_var_set=""
   _denv_write_config

--- a/denv
+++ b/denv
@@ -312,6 +312,9 @@ _denv_deduce_workspace() {
   return 1
 }
 
+_denv_bad_env_var_name_regex="^(HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG_.*_DIRS|^_)"
+_denv_bad_env_value_regex=' |"|`|\$'
+
 # load the denv config from the input workspace
 # Arguments
 #  ${denv_workspace} env var
@@ -350,7 +353,7 @@ _denv_load_config() {
 
   # deduce environment variables from configuration
   # copy-able environment variables, code copied from distrobox
-  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev '^(HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG_.*_DIRS|^_)')"
+  copyable_environment="$(printenv | grep '=' | grep -Ev "'${_denv_bad_env_value_regex}'" | grep -Ev "${_denv_bad_env_var_name_regex}")"
   if [ "${denv_env_var_copy_all}" -eq "1" ]; then
     # deduce env variables, copied from distrobox
     denv_environment="${copyable_environment}"
@@ -557,6 +560,15 @@ _denv_config_env() {
     copy)
       denv_env_var_copy_all=0
       shift
+      if echo "$*" | grep -E "${_denv_bad_env_var_name_regex}"; then
+        _denv_error "The passed variables named above are special and should not be used in the denv."
+        return 1
+      fi
+      if echo "$*" | grep "="; then
+        _denv_error "'denv config env copy' is used for copying environment variables from the host." \
+          "If you want to set an environment variable and ignore the host value, use 'denv config env set'."
+        return 1
+      fi
       # TODO: validate passed variable names
       if [ -z "${denv_env_var_copy}" ]; then
         denv_env_var_copy="$*"
@@ -566,6 +578,14 @@ _denv_config_env() {
       ;;
     set)
       shift
+      if echo "$*" | grep -E "${_denv_bad_env_var_name_regex}"; then
+        _denv_error "The passed variables named above are special and should not be used in the denv."
+        return 1
+      fi
+      if echo "$*" | grep -E "'${_denv_bad_env_value_regex}'"; then
+        _denv_error "Values cannot use special characters (space, slash, tick, etc...)"
+        return 1
+      fi
       # TODO: validate passed varialbe names and values
       if [ -z "${denv_env_var_set}" ]; then
         denv_env_var_set="$*"

--- a/denv
+++ b/denv
@@ -312,7 +312,7 @@ _denv_deduce_workspace() {
   return 1
 }
 
-_denv_bad_env_var_name_regex="^(HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG_.*_DIRS|^_)"
+_denv_bad_env_var_name_regex="^(DENV|HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG_.*_DIRS|^_)"
 
 # load the denv config from the input workspace
 # Arguments

--- a/denv
+++ b/denv
@@ -699,7 +699,7 @@ _denv_init_help() {
   cat <<\HELP
 
   denv init [help|-h|--help] IMAGE [WORKSPACE] [--no-gitignore]
-            [--force] [--name NAME]
+            [--force] [--name NAME] [--no-copy-all]
 
  ARGUMENT
   help       : print this help and exit
@@ -708,10 +708,11 @@ _denv_init_help() {
                optional, defaults to present working directory
   
  OPTIONS
-  -h, --help     : print this help and exit
-  --no-gitignore : don't generate a gitignore for the .denv directory
-  --force        : overwrite an existing denv if it exists
-  --name         : set a name for this denv
+  -h, --help      : print this help and exit
+  --no-gitignore  : don't generate a gitignore for the .denv directory
+  --force         : overwrite an existing denv if it exists
+  --name          : set a name for this denv
+  --no-copy-all   : don't enable copying of host environment variables
 
 HELP
 }
@@ -722,6 +723,7 @@ _denv_init() {
     _denv_error "Provide at least an image to use for running"
     return 1
   fi
+  copyall=1
   gitignore=1
   force=1
   positionals=""
@@ -733,6 +735,9 @@ _denv_init() {
         ;;
       --no-gitignore)
         gitignore=0
+        ;;
+      --no-copy-all)
+        copyall=0
         ;;
       --force)
         force=0
@@ -799,7 +804,11 @@ _denv_init() {
   denv_image="${image}"
   denv_shell="/bin/bash -i"
   denv_mounts=""
-  denv_env_var_copy_all="true"
+  if [ "${copyall}" = "1" ]; then
+    denv_env_var_copy_all="true"
+  else
+    denv_env_var_copy_all="false"
+  fi
   denv_env_var_copy=""
   denv_env_var_set=""
   _denv_write_config

--- a/denv
+++ b/denv
@@ -506,7 +506,7 @@ _denv_config_env_help() {
   denv config env print
   denv config env all {yes|no}
   denv config env copy VAR0[=VAL0] [VAR1[=VAL1] ...]
-  denv config env reset {all|copy|set}
+  denv config env reset
 
  COMMANDS
   help    print this help and exit

--- a/denv
+++ b/denv
@@ -505,8 +505,7 @@ _denv_config_env_help() {
   denv config env [help|-h|--help]
   denv config env print
   denv config env all {yes|no}
-  denv config env copy VAR0 [VAR1 VAR2 ...]
-  denv config env set VAR0=VAL0 [VAR1=VAL1 ...]
+  denv config env copy VAR0[=VAL0] [VAR1[=VAL1] ...]
   denv config env reset {all|copy|set}
 
  COMMANDS
@@ -517,12 +516,12 @@ _denv_config_env_help() {
           will be ignored
   copy    configure denv to copy specific environment variables (the VAR arguments)
           into the denv. This disables the copy all feature as well.
-  set     Set specific environment variables as KEY=VALUE pairs to be defined within
-          the denv.
-  reset   reset the various environment variable lists.
-          all  - reset to the copy all state *AND* clear the copy and set lists
-          copy - clear the copy list
-          set  - clear the set list
+          Any argument with '=' is assumed to be a static KEY=VALUE pair to pass
+          into the denv as an environment variable while arguments without '=' have
+          the VALUE deduced from the host environment (or left unset if the host environment
+          is not set).
+  reset   reset the environment variables to be copied into the denv to an empty state.
+          Clears the lists of environment variables to be copied and sets "all" to "no".
 
 HELP
 }
@@ -564,65 +563,38 @@ _denv_config_env() {
     copy)
       denv_env_var_copy_all="false"
       shift
-      if echo "$*" | grep -E "${_denv_bad_env_var_name_regex}"; then
-        _denv_error "The passed variables named above are special and should not be used in the denv."
-        return 1
-      fi
-      if echo "$*" | grep "="; then
-        _denv_error "'denv config env copy' is used for copying environment variables from the host." \
-          "If you want to set an environment variable and ignore the host value, use 'denv config env set'."
-        return 1
-      fi
-      # TODO: validate passed variable names
-      if [ -z "${denv_env_var_copy}" ]; then
-        denv_env_var_copy="$*"
-      else
-        denv_env_var_copy="${denv_env_var_copy} $*"
-      fi
-      ;;
-    set)
-      shift
-      if echo "$*" | grep -E "${_denv_bad_env_var_name_regex}"; then
-        _denv_error "The passed variables named above are special and should not be used in the denv."
-        return 1
-      fi
-      if echo "$*" | grep -E ' |"|`|\$'; then
-        _denv_error "Values cannot use special characters (space ' ', quote '\"', tick '\`', dollar-sign '$')"
-        return 1
-      fi
-      # TODO: validate passed varialbe names and values
-      if [ -z "${denv_env_var_set}" ]; then
-        denv_env_var_set="$*"
-      else
-        denv_env_var_set="${denv_env_var_set} $*"
-      fi
+      while [ "$#" -gt "0" ]; do
+        if echo "${1}" | grep -E "${_denv_bad_env_var_name_regex}"; then
+          _denv_error "The passed variables named above are special and should not be used in the denv."
+          return 1
+        fi
+        if echo "${1}" | grep -E ' |"|`|\$'; then
+          _denv_error "Values cannot use special characters (space ' ', quote '\"', tick '\`', dollar-sign '$')"
+          return 1
+        fi
+        if echo "${1}" | grep -q "="; then
+          if [ -z "${denv_env_var_set}" ]; then
+            denv_env_var_set="${1}"
+          else
+            denv_env_var_set="${denv_env_var_set} ${1}"
+          fi
+        else
+          if [ -z "${denv_env_var_copy}" ]; then
+            denv_env_var_copy="${1}"
+          else
+            denv_env_var_copy="${denv_env_var_copy} ${1}"
+          fi
+        fi
+        shift
+      done
       ;;
     reset)
-      shift
-      if [ -z "${1}" ]; then
-        _denv_config_env_help
-        _denv_error "'denv config env reset' requires an argument."
-        return 1;
-      fi
-      case "$1" in
-        all)
-          denv_env_var_copy_all="true"
-          denv_env_var_copy=""
-          denv_env_var_set=""
-          ;;
-        copy)
-          denv_env_var_copy=""
-          ;;
-        set)
-          denv_env_var_set=""
-          ;;
-        *)
-          _denv_error "'$1' is not a recognized keyword for 'denv config env reset'"
-          return 1
-      esac
+      denv_env_var_copy_all="true"
+      denv_env_var_copy=""
+      denv_env_var_set=""
       ;;
     *)
-      _denv_error "'$1' is not a recognized keyword 'all', 'copy', or 'set'"
+      _denv_error "'$1' is not a recognized keyword 'help', 'print', 'all', 'copy', or 'reset'"
       return 1
       ;;
   esac

--- a/denv
+++ b/denv
@@ -95,7 +95,7 @@ _denv_mounts_to_args() {
   echo "${mount_args}"
 }
 
-# conver the environment variable related configuration parameters
+# convert the environment variable related configuration parameters
 # to a string list of arguments for the container runner
 # Arguments
 #  1 - option name to prefix each environment variable with
@@ -349,8 +349,7 @@ _denv_load_config() {
   _denv_info "using ${denv_runner} as runner"
 
   # deduce environment variables from configuration
-  #set +o xtrace $ disable tracing even in DEBUG for this snippet since its alot
-  # copy-able environment variables, copied from distrobox
+  # copy-able environment variables, code copied from distrobox
   copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev '^(HOST|HOSTNAME|HOME|LANG|LC_CTYPE|PATH|SHELL|XDG_.*_DIRS|^_)')"
   if [ "${denv_env_var_copy_all}" -eq "1" ]; then
     # deduce env variables, copied from distrobox
@@ -369,8 +368,6 @@ _denv_load_config() {
   denv_environment="${denv_environment} HOME=${denv_workspace}"
 
   if [ -n "${DENV_DEBUG+x}" ]; then
-    # renable trace
-    set -o xtrace
     # add to the environment
     denv_environment="${denv_environment} DENV_DEBUG=${DENV_DEBUG}"
   fi


### PR DESCRIPTION
Explicitly deduce and store a set of environment variables to be put into the container which can then be passed to various runners after being converted to a list of arguments (like `denv_mounts`).

The new logic is mainly in how the list of environment variables is deduced and that is the part that needs the most scrutiny.