### PR TITLE
align podman experience with other runners

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -108,12 +108,7 @@ check_pass denv init ubuntu:22.04 --force --name newname
 # make sure update was applied
 check_equal 'denv printenv DENV_NAME' 'echo newname'
 # check user is passed into the container
-# for podman, we are waiting for idmap to get into a release
-# its already in v4.6.0-rc1
-# https://github.com/containers/podman/commit/82a050a58f2ef2cf940c2ef49e1f8c4b17ab8beb
-if [ "${DENV_RUNNER}" != "podman" ]; then
-  check_equal 'whoami' 'denv whoami'
-fi
+check_equal 'whoami' 'denv whoami'
 # "install" a simple executable and make sure it is available non-interactively
 mkdir -p .local/bin
 cat > .local/bin/hello <<\WORLD

--- a/denv
+++ b/denv
@@ -242,7 +242,7 @@ _denv_run() {
       if [ "${denv_runner}" = "podman" ]; then
         userspec="--userns=keep-id"
       fi
-      # shellcheck disable=SC2086
+      # shellcheck disable=SC2086,SC2248
       ${denv_runner} run \
         --rm \
         --network host \

--- a/denv
+++ b/denv
@@ -252,7 +252,7 @@ _denv_run() {
         ${environment} \
         --workdir "$(pwd -P)" \
         --entrypoint "${denv_entrypoint}" \
-        "${userspec}" \
+        ${userspec} \
         "${denv_image}" \
         "$@"
       ;;

--- a/denv
+++ b/denv
@@ -238,12 +238,9 @@ _denv_run() {
         mounts="${mounts} --volume ${denv_workspace}:${denv_workspace}"
       fi
       environment="$(_denv_environment_to_args --env)"
-      userspec="$(id -u "${USER}"):$(id -g "${USER}")"
-      # until podman makes a release v4.6.0 with idmap
-      # the simplest solution is to just have the in-container user be root
-      # https://github.com/containers/podman/commit/82a050a58f2ef2cf940c2ef49e1f8c4b17ab8beb
+      userspec="--user $(id -u "${USER}"):$(id -g "${USER}")"
       if [ "${denv_runner}" = "podman" ]; then
-        userspec="root"
+        userspec="--userns=keep-id"
       fi
       # shellcheck disable=SC2086
       ${denv_runner} run \
@@ -255,7 +252,7 @@ _denv_run() {
         ${environment} \
         --workdir "$(pwd -P)" \
         --entrypoint "${denv_entrypoint}" \
-        --user "${userspec}" \
+        "${userspec}" \
         "${denv_image}" \
         "$@"
       ;;


### PR DESCRIPTION
I just needed to spend more time with the podman documentation. Using `--userns=keep-id` sets up the container as we want it for `denv` and this goes back to earlier versions of podman (I developed this with the stable 3.4.4 version available in the debian repos.)