### PR TITLE
Manual install singularity from deb

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: install singularity
         if: ${{matrix.runner == 'singularity'}}
         run: |
-          wget https://github.com/apptainer/singularity/releases/download/v3.8.7/singularity-container_3.8.7_amd64.deb
+          wget --no-verbose https://github.com/apptainer/singularity/releases/download/v3.8.7/singularity-container_3.8.7_amd64.deb
           sudo apt install ./singularity-container_3.8.7_amd64.deb
       - uses: eWaterCycle/setup-apptainer@v2
         if: ${{matrix.runner == 'apptainer'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,11 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
-      - uses: eWaterCycle/setup-singularity@v7
+      - name: install singularity
         if: ${{matrix.runner == 'singularity'}}
-        with:
-          singularity-version: 3.8.3
+        run: |
+          wget https://github.com/apptainer/singularity/releases/download/v3.8.7/singularity-container_3.8.7_amd64.deb
+          sudo apt install ./singularity-container_3.8.7_amd64.deb
       - uses: eWaterCycle/setup-apptainer@v2
         if: ${{matrix.runner == 'apptainer'}}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{matrix.runner == 'singularity'}}
         run: |
           wget --no-verbose https://github.com/apptainer/singularity/releases/download/v3.8.7/singularity-container_3.8.7_amd64.deb
-          sudo apt install ./singularity-container_3.8.7_amd64.deb
+          sudo apt-get install ./singularity-container_3.8.7_amd64.deb
       - uses: eWaterCycle/setup-apptainer@v2
         if: ${{matrix.runner == 'apptainer'}}
         with:


### PR DESCRIPTION
this decides our singularity pin to be the last version of singularity
released by apptainer (v3.8.7).  We simply download the deb of that
version and apt install it on ubuntu.

We do not follow sylabs singularity (here referred to as singularityCE).

This will hopefully help this test last longer since the eWaterCycle
action was written for Node 12 but forced to run on Node 16 which I
assume is error prone.