### PR TITLE
test support for singularity ce and document

### DIFF
--- a/.github/workflows/runner-dependabot.yml
+++ b/.github/workflows/runner-dependabot.yml
@@ -1,0 +1,28 @@
+---
+
+name: Test Runners Dependabot
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check-on-runner-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: fetch latest releases
+        run: |
+          ./ci/runner-dependabot --apply 
+          git config --global user.name denv-runner-bot
+          git config --global user.email denv-runner-bot@users.noreply.github.com
+          git switch -c auto-runner-update
+          git add .github/workflows/test.yml
+          git commit -m "Auto Runner Version Update" || exit 0
+          git push -fu origin auto-runner-update
+          gh pr create \
+            --base main \
+            --head auto-runner-update \
+            --title "Auto Runner Version Update" \
+            --body "Written by custom dependabot script that checks for new updates. PR now free to be modified/closed."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,16 @@ jobs:
             version: 3.8.7
           - os: ubuntu-latest
             runner: apptainer
-            version: 1.1.9
+            version: 1.0.0
+          - os: ubuntu-latest
+            runner: apptainer
+            version: 1.2.5
           - os: ubuntu-latest
             runner: sylabs
             version: 3.9.9
+          - os: ubuntu-latest
+            runner: sylabs
+            version: 4.0.2
 #          - os: macos-latest
 #           runner: docker
     runs-on: ${{matrix.os}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,11 @@ jobs:
           - runner: apptainer
             version: 1.0.0
           - runner: apptainer
-            version: 1.2.5 # track apptainer/apptainer
+            version: 1.1.9 # track apptainer/apptainer
           - runner: sylabs
             version: 3.9.9
           - runner: sylabs
-            version: 4.0.2 # track sylabs/singularity
+            version: 4.0.0 # track sylabs/singularity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,34 +27,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         runner: [docker, podman]
         include:
-          - os: ubuntu-latest
-            runner: singularity
+          - runner: singularity
             version: 3.8.7
-          - os: ubuntu-latest
-            runner: apptainer
+          - runner: apptainer
             version: 1.0.0
-          - os: ubuntu-latest
-            runner: apptainer
+          - runner: apptainer
             version: 1.2.5
-          - os: ubuntu-latest
-            runner: sylabs
+          - runner: sylabs
             version: 3.9.9
-          - os: ubuntu-latest
-            runner: sylabs
+          - runner: sylabs
             version: 4.0.2
-#          - os: macos-latest
-#           runner: docker
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: install singularity
         if: ${{matrix.runner == 'singularity' || matrix.runner == 'apptainer' || matrix.runner == 'sylabs'}}
         run: ./ci/install-singularity-flavor ${{matrix.runner}} ${{matrix.version}}
-      - uses: douglascamata/setup-docker-macos-action@v1-alpha
-        if: ${{matrix.os == 'macos-latest'}}
       - name: enable debug mode if requested
         if: ${{runner.debug == '1'}}
         run: echo "DENV_DEBUG=1" >> "$GITHUB_ENV"
@@ -70,3 +60,19 @@ jobs:
           fi
       - name: Test
         run: ./ci/test
+
+#  test-macos:
+#    name: Test on MacOS
+#    runs-on: macos-latest
+#    steps:
+#      - uses: douglascamata/setup-docker-macos-action@v1-alpha
+#      - uses: actions/checkout@v4
+#      - name: enable debug mode if requested
+#        if: ${{runner.debug == '1'}}
+#        run: echo "DENV_DEBUG=1" >> "$GITHUB_ENV"
+#      - name: Install
+#        run: sudo ./install
+#      - name: deduce runner name
+#        run: echo "DENV_RUNNER=docker" >> "$GITHUB_ENV"
+#      - name: Test
+#        run: ./ci/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,11 @@ jobs:
           - runner: apptainer
             version: 1.0.0
           - runner: apptainer
-            version: 1.2.5
+            version: 1.2.5 # track apptainer/apptainer
           - runner: sylabs
             version: 3.9.9
           - runner: sylabs
-            version: 4.0.2
+            version: 4.0.2 # track sylabs/singularity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,22 +28,25 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        runner: [docker, podman, singularity, apptainer]
-#        include:
+        runner: [docker, podman]
+        include:
+          - os: ubuntu-latest
+            runner: singularity
+            version: 3.8.7
+          - os: ubuntu-latest
+            runner: apptainer
+            version: 1.1.9
+          - os: ubuntu-latest
+            runner: sylabs
+            version: 3.9.9
 #          - os: macos-latest
 #           runner: docker
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
       - name: install singularity
-        if: ${{matrix.runner == 'singularity'}}
-        run: |
-          wget --no-verbose https://github.com/apptainer/singularity/releases/download/v3.8.7/singularity-container_3.8.7_amd64.deb
-          sudo apt-get install ./singularity-container_3.8.7_amd64.deb
-      - uses: eWaterCycle/setup-apptainer@v2
-        if: ${{matrix.runner == 'apptainer'}}
-        with:
-          apptainer-version: 1.1.9
+        if: ${{matrix.runner == 'singularity' || matrix.runner == 'apptainer'}}
+        run: ./ci/install-singularity-flavor ${{matrix.runner}} ${{matrix.version}}
       - uses: douglascamata/setup-docker-macos-action@v1-alpha
         if: ${{matrix.os == 'macos-latest'}}
       - name: enable debug mode if requested

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install singularity
-        if: ${{matrix.runner == 'singularity' || matrix.runner == 'apptainer'}}
+        if: ${{matrix.runner == 'singularity' || matrix.runner == 'apptainer' || matrix.runner == 'sylabs'}}
         run: ./ci/install-singularity-flavor ${{matrix.runner}} ${{matrix.version}}
       - uses: douglascamata/setup-docker-macos-action@v1-alpha
         if: ${{matrix.os == 'macos-latest'}}
@@ -54,7 +54,13 @@ jobs:
         run: echo "DENV_DEBUG=1" >> "$GITHUB_ENV"
       - name: Install
         run: sudo ./install
+      - name: deduce runner name
+        run: |
+          installed_runner=${{ matrix.runner }}
+          if [ "${installed_runner}" = "sylabs" ]; then
+            echo "DENV_RUNNER=singularity" >> "$GITHUB_ENV"
+          else
+            echo "DENV_RUNNER=${installed_runner}" >> "$GITHUB_ENV"
+          fi
       - name: Test
-        env:
-          DENV_RUNNER: ${{matrix.runner}}
         run: ./ci/test

--- a/ci/check
+++ b/ci/check
@@ -3,4 +3,4 @@ shellcheck \
   --color=always \
   denv _denv_entrypoint \
   install uninstall \
-  ci/test ci/check ci/set-version
+  ci/test ci/check ci/set-version ci/install-singularity-flavor

--- a/ci/check
+++ b/ci/check
@@ -3,4 +3,6 @@ shellcheck \
   --color=always \
   denv _denv_entrypoint \
   install uninstall \
-  ci/test ci/check ci/set-version ci/install-singularity-flavor
+  ci/test ci/check ci/set-version \
+  ci/install-singularity-flavor \
+  ci/runner-dependabot

--- a/ci/install-singularity-flavor
+++ b/ci/install-singularity-flavor
@@ -32,7 +32,7 @@ singularity() {
   wget \
     --no-verbose \
     -O singularity.deb \
-    https://github.com/apptainer/singularity/releases/download/v${1}/singularity-container_${1}_amd64.deb
+    "https://github.com/apptainer/singularity/releases/download/v${1}/singularity-container_${1}_amd64.deb"
   inf "Downloaded deb build"
   sudo apt-get install ./singularity.deb
   inf "Installed with apt-get install"
@@ -51,7 +51,7 @@ apptainer() {
   wget \
     --no-verbose \
     -O apptainer.deb \
-    https://github.com/apptainer/apptainer/releases/download/v${1}/apptainer_${1}_amd64.deb
+    "https://github.com/apptainer/apptainer/releases/download/v${1}/apptainer_${1}_amd64.deb"
   inf "Downloaded deb build"
   sudo apt-get install ./apptainer.deb
   inf "Installed with apt-get install"
@@ -70,7 +70,7 @@ sylabs() {
   wget \
     --no-verbose \
     -O sylabs.deb \
-    https://github.com/sylabs/singularity/releases/download/v${1}/singularity-ce_${1}-jammy_amd64.deb \
+    "https://github.com/sylabs/singularity/releases/download/v${1}/singularity-ce_${1}-jammy_amd64.deb"
   inf "Downloaded deb build"
   sudo apt-get install ./sylabs.deb
   inf "Installed with apt-get install"
@@ -150,4 +150,4 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-${flavor} ${version}
+${flavor} "${version}"

--- a/ci/install-singularity-flavor
+++ b/ci/install-singularity-flavor
@@ -1,0 +1,153 @@
+#!/bin/sh
+
+set -o nounset
+set -o errexit
+
+# check if passed version string is a valid version
+# ARGS
+#  1 - version string to test
+validate_version() {
+  expr "${1}" : '^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' > /dev/null
+}
+
+error() {
+  printf >&2 "\033[1;31mERROR: \033[0m\033[31m%s\033[0m\n" "$*"
+}
+
+inf() {
+  printf "\033[1mINFO: \033[0m%s\n" "$*"
+}
+
+# install one of the two available original recipe singularity
+# ARGS
+#  1 - version, must be 3.8.6 or 3.8.7
+singularity() {
+  if [ ! "${1}" = "3.8.6" ] && [ ! "${1}" = "3.8.7" ]; then
+    error "Unsupported version number '${1}' for original recipe singularity."
+    exit 1
+  fi
+  # go to temp dir
+  tmp_dir="$(mktemp -d)"
+  cd "${tmp_dir}"
+  wget \
+    --no-verbose \
+    -O singularity.deb \
+    https://github.com/apptainer/singularity/releases/download/v${1}/singularity-container_${1}_amd64.deb
+  inf "Downloaded deb build"
+  sudo apt-get install ./singularity.deb
+  inf "Installed with apt-get install"
+  cd
+  if [ -n "${tmp_dir}" ] && [ -e "${tmp_dir}" ]; then
+    rm -rf "${tmp_dir}"
+  fi
+}
+
+# install one of the versions of apptainer
+# ARGS
+#  1 - version string without preceding v
+apptainer() {
+  tmp_dir="$(mktemp -d)"
+  cd "${tmp_dir}"
+  wget \
+    --no-verbose \
+    -O apptainer.deb \
+    https://github.com/apptainer/apptainer/releases/download/v${1}/apptainer_${1}_amd64.deb
+  inf "Downloaded deb build"
+  sudo apt-get install ./apptainer.deb
+  inf "Installed with apt-get install"
+  cd
+  if [ -n "${tmp_dir}" ] && [ -e "${tmp_dir}" ]; then
+    rm -rf "${tmp_dir}"
+  fi
+}
+
+# install one of the versions of sylabs
+# ARGS
+#  1 - version string without preceding v
+sylabs() {
+  tmp_dir="$(mktemp -d)"
+  cd "${tmp_dir}"
+  wget \
+    --no-verbose \
+    -O sylabs.deb \
+    https://github.com/sylabs/singularity/releases/download/v${1}/singularity-ce_${1}-jammy_amd64.deb \
+  inf "Downloaded deb build"
+  sudo apt-get install ./sylabs.deb
+  inf "Installed with apt-get install"
+  cd
+  if [ -n "${tmp_dir}" ] && [ -e "${tmp_dir}" ]; then
+    rm -rf "${tmp_dir}"
+  fi
+}
+
+help() {
+  cat<<\HELP
+
+  install a singularity flavor on Debian distros using apt-get and deb builds on GitHub.
+
+  This script is highly specialized and mainly meant to help the ubuntu-based GitHub
+  testing actions be a bit more streamlined and contain less copied code. This *will*
+  not work on non-debian distros and *may* not work on non-ubuntu flavors. I've only
+  tested this locally within an ubuntu VM.
+
+ USAGE:
+
+  ./ci/install-singularity-flavor [options] {FLAVOR = singularity|apptainer|sylabs} X.Y.Z
+
+ ARGUMENTS
+  FLAVOR : singularity (original recipe, before sylabs split and apptainer rebranded),
+           apptainer (container runner supported by Linux Foundation),
+           sylabs (SingularityCE maintained by Sylabs)
+  X.Y.Z  : version string to install
+
+ OPTIONS
+  -h, --help : print this help and exit
+
+HELP
+}
+
+if [ "$#" -eq 0 ]; then
+  help
+  exit 0
+fi
+
+flavor=""
+version=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      help
+      exit 0
+      ;;
+    -*)
+      error "Unrecognized option '$1'"
+      exit 1
+      ;;
+    *)
+      if [ -z "${flavor}" ]; then
+        case "$1" in
+          singularity|apptainer|sylabs)
+            flavor="$1"
+            ;;
+          *)
+            error "Unrecognized flavor '$1'"
+            exit 1
+            ;;
+        esac
+      elif [ -z "${version}" ]; then
+        if validate_version "$1"; then
+          version="$1"
+        else
+          error "version string '$1' does not match X.Y.Z"
+          exit 1
+        fi
+      else
+        error "Only two position arguments accepted: FLAVOR X.Y.Z"
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+${flavor} ${version}

--- a/ci/runner-dependabot
+++ b/ci/runner-dependabot
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+error() {
+  printf >&2 "\033[1;31mERROR: \033[0m\033[31m%s\033[0m\n" "$*"
+}
+
+inf() {
+  printf "\033[1mINFO: \033[0m%s\n" "$*"
+}
+
+# fetch the latest release version for the input owner and repo
+# https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release
+# Args
+#  1 : repository
+# Output
+#  prints the tag to stdout
+#  we strip a prefix v if it exists
+fetch() {
+  gh api \
+    -H "Accept: application/vnd.github.json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/${1}/releases/latest" \
+    --jq '.tag_name' \
+    | sed 's|^v||'
+}
+
+# update the test workflow with the passed runner and version
+# Args:
+#  1 : repo name we are tracking
+#  2 : version of that runner
+#  3 : provide to actually apply edit, otherwise just print lines that would change
+# Output:
+#  Edits the .github/workflows/test.yml in place if 3 args provided,
+#  otherwise just prints lines that would be edited to stdout
+update() {
+  sed_cmd="s|version: [0-9.]* # track ${1}|version: ${2} # track ${1}|"
+  if [ -z "${3}" ]; then
+    sed -n "${sed_cmd}p" .github/workflows/test.yml
+  else
+    sed -i "${sed_cmd}" .github/workflows/test.yml
+  fi
+}
+
+help() {
+  cat<<\HELP
+
+  check for new runner versions to test
+
+ USAGE:
+
+  ./ci/runner-dependabot [options]
+
+ OPTIONS
+  -h, --help : print this help and exit
+  --apply    : actually edit the test workflow yaml instead of
+               just printing the lines that have been changed
+
+HELP
+}
+
+apply=""
+while [ "$#" -gt "0" ]; do
+  case "$1" in
+    -h|--help)
+      help
+      exit 0
+      ;;
+    --apply)
+      apply="APPLY"
+      ;;
+    *)
+      help
+      error "Unrecognized argument '$1'"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+for repo in apptainer/apptainer sylabs/singularity
+do
+  latest_release="$(set -o errexit; fetch "${repo}")"
+  inf "Found '${repo}' release '${latest_release}'"
+  update "${repo}" "${latest_release}" "${apply}"
+done
+

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -14,15 +14,16 @@ on the system you wish to use `denv` on. Generally, the runners can be separated
 - Computing Clusters: [apptainer](https://apptainer.org/) or [singularityCE](https://sylabs.io/singularity/)
   - These are commonly chosen by computing clusters due to their ability to be very strictly configured
     so users can run them without elevated priveleges thus avoiding some security vulnerabilities.
-  - `denv` requires the use of the `--env` flag for singularityCE or apptainer which basically means
-    version 3.6 or newer for singularity or any version of apptainer. apptainer currently installs a singularity
-    alias alongside it so - if `singularity --version` returns a value below 3.6, make sure `apptainer` isn't
-    a valid command before concluding that `denv` cannot operate properly.
+  - `denv` requires the use of the `--env` flag for singularity "flavors".
+    This was implemented in version 3.6 for singularity and so any new install of either apptainer or singularityCE
+    should work. Legacy installations of singularity (i.e. versions older than 3.8.7) _should_ function with `denv`
+    (down to version 3.6); however, `denv` only tests version 3.8.7.
 
 [^1]: These groups actually go beyond mere user base. podman grew out of a desire for a under-the-hood redesign
 of docker that is focused on being a drop-in replacement for docker. Even more special, apptainer and singularityCE
-used to be the same project singularity before apptainer joined the Linux Foundation. So these two groupings
-also share tight similarities in their command line interface making them natural groupings for denv.
+used to be the same project singularity before apptainer joined the Linux Foundation and Sylabs continued work on its
+fork of singularity now labeled singularityCE. So these two groupings also share tight similarities in 
+their command line interface making them natural groupings for denv.
 
 ## Installation
 The most recent installation can be obtained by running the install script in the GitHub repository.

--- a/docs/src/new_runner.md
+++ b/docs/src/new_runner.md
@@ -58,8 +58,22 @@ DENV_RUNNER=<your-runner> ./ci/test
 ```
 These can be enabled in your fork of denv so that they run automatically on GitHub
 when you push to a branch on your fork. In order for GitHub to be able to test
-your runner, you will need to install it into the runner during the testing workflow
-(`.github/workflows/test.yml`).
+your runner, you will need to install it into the GitHub runner during the testing 
+workflow (`.github/workflows/test.yml`).
+
+### Tracking New Releases in Test
+I've written up a "dependabot" that will check the latest release of certain GitHub
+repositories and update the testing workflow with those releases if a new one is
+found. In order to follow new releases of the runner being added, you must make
+changes in two places of the CI infrastructure.
+
+1. Add the runner repository (OWNER/REPO) to the `for` loop in `ci/runner-dependabot`.
+2. Place the special comment `# track OWNER/REPO` after the `version:` you wish to be
+   bumped in the testing workflow and make sure your installation procedure will depend
+   (and can handle) the version changing.
+
+Right now, this is done for sylabs/singularity and apptainer/apptainer so look to those
+runners within the testing infrastructure as examples.
 
 Besides the non-interactive tests, there are some additional, manual tests that
 I haven't figured out how to automate since they check interactions between


### PR DESCRIPTION
- Add a CI script for downloading debs from GitHub and installing them with `apt-get`
- Use this CI script to test a few more versions of singularity (including other flavors)

## To Do
- [x] Update documentation wording to use the same vocabulary here
- [x] Research ways of updating tests to follow new apptainer and sylabs/singularity versions