### PR TITLE
79 sub command to check if a supported runner is available

### DIFF
--- a/ci/gen-man
+++ b/ci/gen-man
@@ -22,7 +22,7 @@ _translate() {
     -o man/man1/${man_page}.1
 }
 
-for page in denv denv-init denv-config
+for page in denv denv-init denv-config denv-check
 do
   _translate "${page}"
 done

--- a/completions/denv
+++ b/completions/denv
@@ -10,7 +10,7 @@ __denv() {
 
   if [[ "${COMP_CWORD}" = "1" ]]; then
     # tab completing main argument
-    COMPREPLY=($(compgen -W "init config help version ${DENV_TAB_COMMANDS}" "$curr_word"))
+    COMPREPLY=($(compgen -W "init config help version check ${DENV_TAB_COMMANDS}" "$curr_word"))
   elif [[ "${COMP_CWORD}" = "2" ]]; then
     # tab complete a sub-argument which depends on main argument
     case "${COMP_WORDS[1]}" in
@@ -20,6 +20,9 @@ __denv() {
         ;;
       config)
         COMPREPLY=($(compgen -W "help print image mounts shell env" "$curr_word"))
+        ;;
+      check)
+        COMPREPLY=($(compgen -W "-h --help -q --quiet" "$curr_word"))
         ;;
       *)
         # re-enable normal tab completion for everything else

--- a/denv
+++ b/denv
@@ -858,10 +858,54 @@ _denv_version() {
 
 # check that denv was installed alongside its entrypoint and there
 # is a runner available to use
+_denv_check_help() {
+  cat <<\HELP
+
+  denv check [-h, --help] [-q, --quiet]
+
+ DESCRIPTION
+  Check denv installation to make sure the entrypoint exists as
+  an executable file in the expected location and there is at least
+  one container runner available for denv to use.
+
+  This command (without the -q, --quiet flag) lists the runners it
+  is looking for, the ones that it has found, and which runner will
+  be used by default if DENV_RUNNER is not set in the environment.
+
+  EXIT CODES
+    0   : success, denv installation is complete and there is a supported runner to use
+    1   : failure, denv cannot find the entrypoint script it needs
+    2   : failure, denv cannot find a supported runner to use
+    127 : denv check was supplied an argument it didn't recognize
+
+ OPTIONS
+  -h, --help  : print this help and exit
+  -q, --quiet : suppress non-error output, i.e. will silently return 0 if
+                denv can function properly
+
+HELP
+}
 _denv_check() {
+  quiet=false
+  while [ "$#" -gt "0" ]; do
+    case "$1" in
+      -h|--help)
+        _denv_check_help
+        return 0
+        ;;
+      -q|--quiet)
+        quiet=true
+        ;;
+      *)
+        _denv_error "Unrecognized 'denv check' option '$1'"
+        return 127
+        ;;
+    esac
+    shift
+  done
   # check for entrypoint
   if [ -x "${denv_entrypoint}" ] && [ -f "${denv_entrypoint}" ]; then
-    printf "\033[32mEntrypoint found alongside denv\033[0m\n"
+    ${quiet} || printf "\033[32mEntrypoint found alongside denv\033[0m\n"
   else
     _denv_error "_denv_entrypoint does not exist as an executable file alongside denv"
     return 1
@@ -873,13 +917,11 @@ _denv_check() {
   # the user which runner would be deduced when running
   for possible in docker podman apptainer singularity;
   do
-    printf "Looking for %s... " "${possible}"
-    # apptainer includes a symlink to singularity, so we have to 
-    # check for the command's existence and make sure its not just a symlink
+    ${quiet} || printf "Looking for %s... " "${possible}"
     if command -v "${possible}" >/dev/null 2>&1 && [ ! -L "$(which "${possible}")" ]; then
-      printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
+      ${quiet} || printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
       if [ "${first}" = "true" ]; then
-        printf "\033[32;1m default\033[0m (override with DENV_RUNNER)"
+        ${quiet} || printf "\033[32;1m <- would use without DENV_RUNNER defined\033[0m"
         first="false"
       fi
       # extra version compatibility checking
@@ -890,8 +932,8 @@ _denv_check() {
           minor="$(echo "${version}" | cut -f 2 -d '.')"
           #patch="$(echo "${version}" | cut -f 3 -d '.')" # not used
           if [ "${major}" -lt "3" ] || [ "${major}" -eq "3" ] && [ "${minor}" -lt "6" ]; then
-            printf "\n"
-            printf "\033[31m    denv requires the --env flag for singularity which was introduced in v3.6\033[0m"
+            ${quiet} || printf "\n"
+            _denv_error "denv requires the --env flag for singularity which was introduced in v3.6"
           fi
           ;;
         *)
@@ -899,13 +941,13 @@ _denv_check() {
           ;;
       esac
     else
-      printf "not found"
+      ${quiet} || printf "not found"
     fi
-    printf "\n"
+    ${quiet} || printf "\n"
   done
   if [ "${first}" = "true" ]; then
     _denv_error "No container runner found!"
-    return 1
+    return 2
   fi
   return 0
 }

--- a/denv
+++ b/denv
@@ -873,7 +873,7 @@ _denv_check() {
   # the user which runner would be deduced when running
   for possible in docker podman apptainer singularity;
   do
-    printf "Looking for ${possible}... "
+    printf "Looking for %s... " "${possible}"
     if command -v "${possible}" >/dev/null 2>&1; then
       printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
       if [ "${first}" = "true" ]; then
@@ -886,7 +886,7 @@ _denv_check() {
           version="$(singularity version | cut -f 1 -d '-')"
           major="$(echo "${version}" | cut -f 1 -d '.')"
           minor="$(echo "${version}" | cut -f 2 -d '.')"
-          patch="$(echo "${version}" | cut -f 3 -d '.')"
+          #patch="$(echo "${version}" | cut -f 3 -d '.')" # not used
           if [ "${major}" -lt "3" ] || [ "${major}" -eq "3" ] && [ "${minor}" -lt "6" ]; then
             printf "\n"
             printf "\033[31m    denv requires the --env flag for singularity which was introduced in v3.6\033[0m"

--- a/denv
+++ b/denv
@@ -874,10 +874,12 @@ _denv_check() {
   for possible in docker podman apptainer singularity;
   do
     printf "Looking for %s... " "${possible}"
-    if command -v "${possible}" >/dev/null 2>&1; then
+    # apptainer includes a symlink to singularity, so we have to 
+    # check for the command's existence and make sure its not just a symlink
+    if command -v "${possible}" >/dev/null 2>&1 && [ ! -L "$(which "${possible}")" ]; then
       printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
       if [ "${first}" = "true" ]; then
-        printf "\033[32;1m <- would use without DENV_RUNNER defined\033[0m"
+        printf "\033[32;1m default\033[0m (override with DENV_RUNNER)"
         first="false"
       fi
       # extra version compatibility checking

--- a/denv
+++ b/denv
@@ -345,6 +345,7 @@ _denv_load_config() {
   # shellcheck disable=SC1091
   . "${denv_workspace}/.denv/config"
   denv_image_cache="${denv_workspace}/.denv/images"
+  # make sure to update _denv_check if the order of this elif tree is changed
   if [ -n "${DENV_RUNNER+x}" ]; then
     denv_runner="${DENV_RUNNER}"
     if [ ! "${denv_runner}" = "norunner" ] && ! command -v "${denv_runner}" >/dev/null 2>&1; then
@@ -855,6 +856,58 @@ _denv_version() {
   echo "denv v${denv_version}"
 }
 
+# check that denv was installed alongside its entrypoint and there
+# is a runner available to use
+_denv_check() {
+  # check for entrypoint
+  if [ -x "${denv_entrypoint}" ] && [ -f "${denv_entrypoint}" ]; then
+    printf "\033[32mEntrypoint found alongside denv\033[0m\n"
+  else
+    _denv_error "_denv_entrypoint does not exist as an executable file alongside denv"
+    return 1
+  fi
+
+  first="true"
+  # the order in this for loop should be the same as the order of
+  # the elif-tree in _denv_load_config so that we correctly inform
+  # the user which runner would be deduced when running
+  for possible in docker podman apptainer singularity;
+  do
+    printf "Looking for ${possible}... "
+    if command -v "${possible}" >/dev/null 2>&1; then
+      printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
+      if [ "${first}" = "true" ]; then
+        printf "\033[32;1m <- would use without DENV_RUNNER defined\033[0m"
+        first="false"
+      fi
+      # extra version compatibility checking
+      case "${possible}" in
+        singularity)
+          version="$(singularity version | cut -f 1 -d '-')"
+          major="$(echo "${version}" | cut -f 1 -d '.')"
+          minor="$(echo "${version}" | cut -f 2 -d '.')"
+          patch="$(echo "${version}" | cut -f 3 -d '.')"
+          if [ "${major}" -lt "3" ] || [ "${major}" -eq "3" ] && [ "${minor}" -lt "6" ]; then
+            printf "\n"
+            printf "\033[31m    denv requires the --env flag for singularity which was introduced in v3.6\033[0m"
+          fi
+          ;;
+        *)
+          # fall through, don't do extra checking
+          ;;
+      esac
+    else
+      printf "not found"
+    fi
+    printf "\n"
+  done
+  if [ "${first}" = "true" ]; then
+    _denv_error "No container runner found!"
+    return 1
+  fi
+  return 0
+}
+
 # root program denv
 _denv_help() {
   cat <<\HELP
@@ -889,7 +942,7 @@ _denv() {
       _denv_help
       return 
       ;;
-    version|help|config|init)
+    version|help|config|init|check)
       cmd="_denv_${1}"
       shift
       # I think I know what I'm doing here

--- a/docs/src/manual/denv-check.md
+++ b/docs/src/manual/denv-check.md
@@ -1,0 +1,29 @@
+# NAME
+
+denv check
+
+# SYNOPSIS
+
+**denv check** [-h|--help] [-q|--quiet]
+
+# OPTIONS
+
+**`--help`** or **`-h`** print a short help message
+
+**`--quiet`** or **`-q`** suppress non-error output
+
+# EXIT CODES
+
+**`denv check`** follows the POSIX convention of returning a non-zero exit code when a
+failure condition is encountered.
+
+Code | Description
+---|---
+0 | success, denv installation is complete and there is a supported runner to use (or the user printed the help message)
+1 | failure, denv cannot find the entrypoint script as an executable in the directory it is installed in
+2 | failure, denv cannot find a supported runner to use
+127 | denv check was supplied an argument it didn't recognize
+
+# SEE ALSO
+
+**denv(1)**, **denv-config(1)**, **denv-init(1)**

--- a/docs/src/manual/denv-config.md
+++ b/docs/src/manual/denv-config.md
@@ -202,4 +202,4 @@ is needed. **`denv`** assumes that this config file defines the following shell 
 
 # SEE ALSO
 
-**denv(1)**, **denv-init(1)**
+**denv(1)**, **denv-init(1)**, **denv-check(1)**

--- a/docs/src/manual/denv-init.md
+++ b/docs/src/manual/denv-init.md
@@ -59,4 +59,4 @@ the same name as above, the denvs will appear similar even though their workspac
 
 # SEE ALSO
 
-**denv(1)**, **denv-config(1)**
+**denv(1)**, **denv-config(1)**, **denv-check(1)**

--- a/docs/src/manual/denv.md
+++ b/docs/src/manual/denv.md
@@ -12,6 +12,8 @@ denv v0.5.0
 
 **denv** config [args]
 
+**denv** check [-h, --help] [-q, --quiet]
+
 **denv** [COMMAND] [args...]
 
 # DESCRIPTION
@@ -32,6 +34,8 @@ within the specialized and isolated environment.
 **`init`** initialize a new denv. See **denv-init(1)** for details.
 
 **`config`** manipulate the configuration of the current denv. See **denv-config(1)** for details.
+
+**`check`** check the installation of denv and look for supported container runners. See **denv-check(1)** for details.
 
 **`COMMAND`** any other command not matching one of the options above is provided to the
               configured denv to run within the containerized environment. The rest of the
@@ -81,7 +85,7 @@ already be defined.
 
 # SEE ALSO
 
-**denv-init(1)**, **denv-config(1)**
+**denv-init(1)**, **denv-config(1)**, **denv-check(1)**
 
 # ENVIRONMENT
 

--- a/docs/src/manual/denv.md
+++ b/docs/src/manual/denv.md
@@ -103,6 +103,9 @@ to modify its behavior in an advanced way without having to provide many command
     does not exist
   - **denv init** and **denv config image** will not pull an image if it already exists
 
+  **DENV_TAB_COMMANDS** a space-separated list of commands to include in tab-completions of denv.
+  This is helpful if there are a set of common commands you use within the denv.
+
 # FILES
 
 This part of the manual is an attempt to list and explain the files within a `.denv` directory.

--- a/test/config.bats
+++ b/test/config.bats
@@ -19,6 +19,21 @@ teardown() {
   assert_output
 }
 
+@test "print check help" {
+  run denv check --help
+  assert_output
+}
+
+@test "basic check run" {
+  run denv check
+  assert_output
+}
+
+@test "quiet check run" {
+  run denv check --quiet
+  refute_output
+}
+
 @test "print config" {
   run denv config print
   assert_line --index 0 "denv_workspace=\"${PWD}\""


### PR DESCRIPTION
This introduces a new `denv` sub-command named `check` that 

1. Makes sure the `_denv_entrypoint` is where it is expected to be.
2. Looks for a supported runner that `denv` can use

This new command also has a `--quiet` version which silently reports success if there are no errors encountered.