### PR TITLE
81 disable network connection when running

### DIFF
--- a/completions/denv
+++ b/completions/denv
@@ -19,7 +19,7 @@ __denv() {
         COMPREPLY=()
         ;;
       config)
-        COMPREPLY=($(compgen -W "help print image mounts shell env" "$curr_word"))
+        COMPREPLY=($(compgen -W "help print image mounts shell network env" "$curr_word"))
         ;;
       check)
         COMPREPLY=($(compgen -W "-h --help -q --quiet" "$curr_word"))
@@ -39,6 +39,9 @@ __denv() {
       mounts)
         # directory tab completion
         COMPREPLY=($(compgen -d -- "$curr_word"))
+        ;;
+      network)
+        COMPREPLY=($(compgen -W "yes on true no off false" "$curr_word"))
         ;;
       env)
         if [[ "${COMP_CWORD}" = "3" ]]; then

--- a/denv
+++ b/denv
@@ -236,10 +236,12 @@ _denv_run() {
       if [ "${denv_runner}" = "podman" ]; then
         userspec="--userns=keep-id"
       fi
+      network="host"
+      [ "${denv_network}" = "false" ] && network="none"
       # shellcheck disable=SC2086,SC2248
       ${denv_runner} run \
         --rm \
-        --network host \
+        --network "${network}" \
         ${interactive} \
         ${mounts} \
         --hostname "${_hostname}" \
@@ -256,8 +258,11 @@ _denv_run() {
       mounts="$(_denv_mounts_to_args "--bind")"
       sif_file="${denv_image_cache}/$(_denv_image_to_filename).sif"
       environment="$(_denv_environment_to_args "--env")"
+      network=""
+      [ "${denv_network}" = "false" ] && network="--net --network none"
       # shellcheck disable=SC2086
       PWD=$(pwd -P) ${denv_runner} exec \
+        ${network} \
         --hostname "${_hostname}" \
         --home "${denv_workspace}" \
         --cleanenv \
@@ -268,10 +273,13 @@ _denv_run() {
         "$@"
       ;;
     norunner)
+      network="enabled"
+      [ "${denv_network}" = "false" ] && network="disabled"
       _denv_info "running ${denv_image} with " \
         "  HOME=\"${denv_workspace}\"" \
         "  SHELL=\"${denv_shell}\"" \
         "  PWD=\"$(pwd -P)\"" \
+        "  network ${network}" \
         "${denv_environment}" \
         "${denv_mounts}"
       ;;
@@ -422,6 +430,7 @@ _denv_write_config() {
     echo "denv_env_var_copy_all=\"${denv_env_var_copy_all}\"";
     echo "denv_env_var_copy=\"${denv_env_var_copy}\"";
     echo "denv_env_var_set=\"${denv_env_var_set}\"";
+    echo "denv_network=\"${denv_network}\"";
   } > "${config}"
 }
 
@@ -437,6 +446,7 @@ _denv_config_print() {
   printf "%s=\"%s\"\n" denv_image "${denv_image}"
   printf "%s=\"%s\"\n" denv_mounts "${denv_mounts}"
   printf "%s=\"%s\"\n" denv_shell "${denv_shell}"
+  printf "%s=\"%s\"\n" denv_network "${denv_network}"
   _denv_runner
   if [ ! "${denv_env_var_copy_all}" = "true" ] || [ -n "${1:-}" ]; then
     _denv_config_env print
@@ -515,6 +525,21 @@ _denv_config_mounts() {
   done
 }
 
+# enable/disable the network connection within the denv
+_denv_config_network() {
+  case "$1" in
+    yes|true|on)
+      denv_network="true"
+      ;;
+    no|false|off)
+      denv_network="false"
+      ;;
+    *)
+      _denv_error "'$1' is not 'yes', 'on', or 'true' nor 'no', 'off', or 'false'"
+      ;;
+  esac
+}
+
 # configure environment variables for within the denv
 # Arguments
 #  1 - {all,copy,set}
@@ -576,7 +601,7 @@ _denv_config_env() {
           denv_env_var_copy_all="true"
           ;;
         *)
-          _denv_error "'$1' is not 'yes' or no'"
+          _denv_error "'$1' is not 'yes', 'on', or 'true' nor 'no', 'off', or 'false'"
           return 1;
           ;;
       esac
@@ -637,6 +662,7 @@ _denv_config_help() {
   denv config image [pull|IMAGE]
   denv config mounts DIR0 [DIR1 DIR2 ...]
   denv config shell SHELL
+  denv config network {[yes|true|on]|[no|false|off]}
   denv config env [args...]
 
  COMMANDS
@@ -650,6 +676,8 @@ _denv_config_help() {
   mounts  add one or more directories to be mounted to the denv
   shell   change which program is executed when opening
           the denv without any arguments
+  network enable connecting the network to the denv (passing yes, true, or on),
+          or disable connecting the network (passing no, false, or off).
   env     configure which environment variables are put
           into the container environment
           `denv config env help` for more detail
@@ -667,7 +695,7 @@ _denv_config() {
       cmd="_denv_config_${1}"
       ${cmd} "${2:-}"
       ;;
-    image|shell|mounts|env)
+    image|shell|mounts|network|env)
       if [ "$1" = "env" ]; then
         # need to check for help printout before loading config
         # so users can access help information without a denv
@@ -827,6 +855,7 @@ _denv_init() {
   denv_image="${image}"
   denv_shell="/bin/bash -i"
   denv_mounts=""
+  denv_network="true"
   if [ "${copyall}" = "1" ]; then
     denv_env_var_copy_all="true"
   else

--- a/docs/src/manual/denv-config.md
+++ b/docs/src/manual/denv-config.md
@@ -14,6 +14,8 @@ denv config
 
 **denv config** shell SHELL
 
+**denv config** network {[yes|on|true]|[no|off|false]}
+
 **denv config** env [help|-h|--help]
 
 **denv config** env print
@@ -47,6 +49,9 @@ after 'config'.
 **mounts** provide additional directories to mount into the denv during running.
 
 **shell** set the shell that should be executed by denv if no other command is given by the user.
+
+**network** enable network connection for the denv (passing yes, on, or true) or disable this
+            network connection (passing no, off, or false).
 
 **env** manipulate and view the environment variables that will be provided to the denv at run time.
 
@@ -199,6 +204,8 @@ is needed. **`denv`** assumes that this config file defines the following shell 
     on the names and values that can be kept here so editing this value directly is not recommended.
     Use **`denv config env copy`** to edit this value while validating that the rules are followed.
 
+  **denv_network** a boolean flag signalling if **`denv`** should connect the container to the host
+    network (`"true"`) or disable all network connection (`"false"`).
 
 # SEE ALSO
 

--- a/docs/src/manual/denv-init.md
+++ b/docs/src/manual/denv-init.md
@@ -57,6 +57,15 @@ the same name as above, the denvs will appear similar even though their workspac
 
     denv init python:3.11 py311
 
+# DEFAULT CONFIGURATION
+**denv init** makes the following choices on configuration that can later be edited by **denv config**
+if the user desires.
+
+  - The interative shell is `/bin/bash -i`, change with **`denv config shell PROGRAM`**
+  - No specific environment variables are copied from the host or set to specific values, change with **`denv config env copy VAR[=VAL]`**. The denv either copies all host environment variables (the default) or none (with `--clean-env`).
+  - No extra diretories are mounted into the denv (besides those automatically mounted by the underlying container runner, e.g. apptainer auto-mounts `/tmp`), update with **`denv config mounts DIR`**.
+  - The denv is connected to the host's network, disable with **`denv config network off`**.
+
 # SEE ALSO
 
 **denv(1)**, **denv-config(1)**, **denv-check(1)**

--- a/docs/src/new_runner.md
+++ b/docs/src/new_runner.md
@@ -110,8 +110,9 @@ jupyter. **Note**: Developers should know that these images have
 a very special user and entrypoint configuration specialized for
 jupyter lab which may cause extra complications.
 
-The non-interactive tests _do_ check for network devices within
-the container by inspecting the output of `ls /sys/class/net`
-in order to confirm that we can enable/disable network connection.
-I do not expect this to be enough to guarantee network functionality
-especially for new runners that I am not familiar with.
+The non-interactive tests _do_ check for network connection within
+the container by attempting to connect a socket to a public Google
+DNS server. I do not expect this to be enough to guarantee network
+functionality especially for new runners that I am not familiar with.
+Any aid in more precisely testing external network connection as well
+as "localhost"-style connection would be an appreciated contribution.

--- a/docs/src/new_runner.md
+++ b/docs/src/new_runner.md
@@ -109,3 +109,9 @@ The user should be able to access the localhost link displayed by
 jupyter. **Note**: Developers should know that these images have
 a very special user and entrypoint configuration specialized for
 jupyter lab which may cause extra complications.
+
+The non-interactive tests _do_ check for network devices within
+the container by inspecting the output of `ls /sys/class/net`
+in order to confirm that we can enable/disable network connection.
+I do not expect this to be enough to guarantee network functionality
+especially for new runners that I am not familiar with.

--- a/test/config.bats
+++ b/test/config.bats
@@ -58,3 +58,9 @@ teardown() {
   denv config shell /bin/zsh
   assert_file_contains .denv/config '^denv_shell="/bin/zsh"$'
 }
+
+@test "disable network connection" {
+  assert_file_contains .denv/config '^denv_network="true"$'
+  denv config network off
+  assert_file_contains .denv/config '^denv_network="false"$'
+}

--- a/test/internet-access.py
+++ b/test/internet-access.py
@@ -1,0 +1,24 @@
+"""python3 script to quick check if network is accessible
+
+https://stackoverflow.com/a/33117579
+"""
+
+import socket
+
+def internet(host="8.8.8.8", port=53, timeout=3):
+    """
+    Host: 8.8.8.8 (google-public-dns-a.google.com)
+    OpenPort: 53/tcp
+    Service: domain (DNS/TCP)
+    """
+    try:
+        socket.setdefaulttimeout(timeout)
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
+        return True
+    except socket.error as ex:
+        print(ex)
+        return False
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(0 if internet() else 1)

--- a/test/network.bats
+++ b/test/network.bats
@@ -1,31 +1,31 @@
 #!/usr/bin/env bats
 
-setup() {
+setup_file() {
   load "test_helper/denv"
   common_setup
   
   go_to_tmp_work
-  denv init ubuntu:22.04
+  denv init python
+  cp -t . ${OLDPWD}/test/internet-access.py
 }
 
-teardown() {
+setup() {
+  load "test_helper/denv"
+  common_setup
+}
+
+teardown_file() {
   clean_tmp_work
 }
 
-@test "we can see other network devices besides loopback" {
-  run denv ls /sys/class/net
+@test "we can connect a socket to a Google public DNS server" {
+  run denv python3 internet-access.py
   assert_success
-  # --partial, the loopback device is there
-  assert_container_output --partial "lo"
-  # the number of devices is more than one
-  num_devices="$(echo "${output}" | wc -w)"
-  assert [ "$num_devices" -gt 1 ]
+  refute_output
 }
 
-@test "we can disable network devices besides loopback" {
+@test "we can disable network devices" {
   denv config network off
-  run denv ls /sys/class/net
-  assert_success
-  # no --partial => the only output is the 'lo' loopback
-  assert_container_output "lo"
+  run -1 denv python3 internet-access.py
+  assert_output
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "test_helper/denv"
+  common_setup
+  
+  go_to_tmp_work
+  denv init ubuntu:22.04
+}
+
+teardown() {
+  clean_tmp_work
+}
+
+@test "we can see other network devices besides loopback" {
+  run denv ls /sys/class/net
+  assert_success
+  assert_container_output --partial "lo"
+  num_devices="$(echo "${output}" | wc -w)"
+  assert [ "$num_devices" -gt 1 ]
+}
+
+@test "we can disable network devices besides loopback" {
+  export DENV_NETWORKLESS=1
+  run denv ls /sys/class/net
+  assert_success
+  # no --partial => the only output is the 'lo' loopback
+  assert_container_output "lo"
+}

--- a/test/network.bats
+++ b/test/network.bats
@@ -15,13 +15,15 @@ teardown() {
 @test "we can see other network devices besides loopback" {
   run denv ls /sys/class/net
   assert_success
+  # --partial, the loopback device is there
   assert_container_output --partial "lo"
+  # the number of devices is more than one
   num_devices="$(echo "${output}" | wc -w)"
   assert [ "$num_devices" -gt 1 ]
 }
 
 @test "we can disable network devices besides loopback" {
-  export DENV_NETWORKLESS=1
+  denv config network off
   run denv ls /sys/class/net
   assert_success
   # no --partial => the only output is the 'lo' loopback


### PR DESCRIPTION
Testing network connection non-interactively was a bit annoying, but actually implementing it in the runners to either use the host network or not use any network was pretty simple.