### PR TITLE
update `denv check` with emulation testing and workspace search

### DIFF
--- a/denv
+++ b/denv
@@ -361,10 +361,10 @@ _denv_load_config() {
         "You should only be setting DENV_RUNNER if you have more than one runner installed and wish to use denv with a specific one."
       return 1
     fi
-  elif command -v docker >/dev/null 2>&1; then
-    denv_runner="docker"
   elif command -v podman >/dev/null 2>&1; then
     denv_runner="podman"
+  elif command -v docker >/dev/null 2>&1; then
+    denv_runner="docker"
   elif command -v apptainer >/dev/null 2>&1; then
     denv_runner="apptainer"
   elif command -v singularity >/dev/null 2>&1; then
@@ -949,50 +949,50 @@ _denv_check() {
   # the order in this for loop should be the same as the order of
   # the elif-tree in _denv_load_config so that we correctly inform
   # the user which runner would be deduced when running
-  for possible in docker podman apptainer singularity;
+  for possible in podman docker apptainer singularity;
   do
     ${quiet} || printf "Looking for %s... " "${possible}"
-    if ${denv_runner_defined}; then
-      if [ "${possible}" = "${DENV_RUNNER}" ]; then
-        denv_runner_matched=true
-        ${quiet} || printf "DENV_RUNNER"
-      fi
-    fi
     if command -v "${possible}" >/dev/null 2>&1; then
       # extra version compatibility checking
       case "${possible}" in
         singularity)
-          if singularity --version 2>&1 | grep -q apptainer; then
-            ${quiet} || printf "found 'apptainer emulating singularity'\n"
-            continue
-          fi
           version="$(singularity version | cut -f 1 -d '-')"
           major="$(echo "${version}" | cut -f 1 -d '.')"
           minor="$(echo "${version}" | cut -f 2 -d '.')"
           #patch="$(echo "${version}" | cut -f 3 -d '.')" # not used
-          if [ "${major}" -lt "3" ] || [ "${major}" -eq "3" ] && [ "${minor}" -lt "6" ]; then
+          if singularity --version 2>&1 | grep -q apptainer; then
+            ${quiet} || printf "found apptainer emulating singularity"
+          elif [ "${major}" -lt "3" ] || [ "${major}" -eq "3" ] && [ "${minor}" -lt "6" ]; then
             ${quiet} || printf "found '%s', but " "$(singularity --version)"
             ${quiet} || printf "\033[31m%s\033[0m" \
-              "denv requires the --env flag for singularity which was introduced in v3.6\n"
-            continue
+              "denv requires the --env flag for singularity which was introduced in v3.6"
+          else
+            ${quiet} || printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
           fi
           ;;
         docker)
           # check for podman emulation of docker
           # if podman is emulating docker, docker --version will return podman --version
           # which includes 'podman'
-          if docker --version 2>&1 | grep -q podman; then
-            ${quiet} || printf "found 'podman emulating docker'\n"
-            continue
+          if docker version 2>&1 | grep -iq podman; then
+            ${quiet} || printf "found podman emulating docker"
+          else
+            ${quiet} || printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
           fi
           ;;
         *)
-          # fall through, don't do extra checking
+          # no extra checking, just print the version found
+          ${quiet} || printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
           ;;
       esac
-      ${quiet} || printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
+      if ${denv_runner_defined}; then
+        if [ "${possible}" = "${DENV_RUNNER}" ]; then
+          denv_runner_matched=true
+          ${quiet} || printf "\033[32;1m <- DENV_RUNNER\033[0m"
+        fi
+      fi
       if [ "${first}" = "true" ]; then
-        ${quiet} || printf "\033[32;1m <- would use without DENV_RUNNER defined\033[0m"
+        ${quiet} || printf "\033[32;1m <- use without DENV_RUNNER defined\033[0m"
         first="false"
       fi
     else

--- a/denv
+++ b/denv
@@ -909,6 +909,7 @@ _denv_check_help() {
     1   : failure, denv cannot find the entrypoint script it needs
     2   : failure, denv cannot find a supported runner to use
     3   : failure, DENV_RUNNER is defined to a runner that denv does not support
+          or is not an available program on the current machine
     4   : failure, denv cannot deduce a workspace (i.e. no 'denv init' has happened yet)
           only tested if the --workspace option is provided
     127 : denv check was supplied an argument it didn't recognize
@@ -1016,7 +1017,8 @@ _denv_check() {
     return 2
   fi
   if ${denv_runner_defined} && ! ${denv_runner_matched}; then
-    _denv_error "DENV_RUNNER=${DENV_RUNNER} but this runner is not supported by denv"
+    _denv_error "DENV_RUNNER=${DENV_RUNNER} but this runner is not supported by denv" \
+      "(or is not available on this machine)"
     return 3
   fi
   if ${workspace}; then

--- a/denv
+++ b/denv
@@ -953,10 +953,12 @@ _denv_check() {
   fi
 
   first="true"
+  would_run_with="norunner"
   denv_runner_defined=false
   denv_runner_matched=false
   if [ -n "${DENV_RUNNER:+x}" ]; then
     denv_runner_defined=true
+    would_run_with="${DENV_RUNNER}"
   fi
   # the order in this for loop should be the same as the order of
   # the elif-tree in _denv_load_config so that we correctly inform
@@ -1006,6 +1008,7 @@ _denv_check() {
       if [ "${first}" = "true" ]; then
         ${quiet} || printf "\033[32;1m <- use without DENV_RUNNER defined\033[0m"
         first="false"
+        ${denv_runner_defined} || would_run_with="${possible}"
       fi
     else
       ${quiet} || printf "not found"
@@ -1015,6 +1018,8 @@ _denv_check() {
   if [ "${first}" = "true" ]; then
     _denv_error "No container runner found!"
     return 2
+  else
+    ${quiet} || printf "denv would run with '%s'\n" "${would_run_with}"
   fi
   if ${denv_runner_defined} && ! ${denv_runner_matched}; then
     _denv_error "DENV_RUNNER=${DENV_RUNNER} but this runner is not supported by denv" \

--- a/denv
+++ b/denv
@@ -941,34 +941,60 @@ _denv_check() {
   fi
 
   first="true"
+  denv_runner_defined=false
+  denv_runner_matched=false
+  if [ -n "${DENV_RUNNER:+x}" ]; then
+    denv_runner_defined=true
+  fi
   # the order in this for loop should be the same as the order of
   # the elif-tree in _denv_load_config so that we correctly inform
   # the user which runner would be deduced when running
   for possible in docker podman apptainer singularity;
   do
     ${quiet} || printf "Looking for %s... " "${possible}"
-    if command -v "${possible}" >/dev/null 2>&1 && [ ! -L "$(which "${possible}")" ]; then
-      ${quiet} || printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
-      if [ "${first}" = "true" ]; then
-        ${quiet} || printf "\033[32;1m <- would use without DENV_RUNNER defined\033[0m"
-        first="false"
+    if ${denv_runner_defined}; then
+      if [ "${possible}" = "${DENV_RUNNER}" ]; then
+        denv_runner_matched=true
+        ${quiet} || printf "DENV_RUNNER"
       fi
+    fi
+    if command -v "${possible}" >/dev/null 2>&1; then
       # extra version compatibility checking
       case "${possible}" in
         singularity)
+          if singularity --version 2>&1 | grep -q apptainer; then
+            ${quiet} || printf "found 'apptainer emulating singularity'\n"
+            continue
+          fi
           version="$(singularity version | cut -f 1 -d '-')"
           major="$(echo "${version}" | cut -f 1 -d '.')"
           minor="$(echo "${version}" | cut -f 2 -d '.')"
           #patch="$(echo "${version}" | cut -f 3 -d '.')" # not used
           if [ "${major}" -lt "3" ] || [ "${major}" -eq "3" ] && [ "${minor}" -lt "6" ]; then
-            ${quiet} || printf "\n"
-            _denv_error "denv requires the --env flag for singularity which was introduced in v3.6"
+            ${quiet} || printf "found '%s', but " "$(singularity --version)"
+            ${quiet} || printf "\033[31m%s\033[0m" \
+              "denv requires the --env flag for singularity which was introduced in v3.6\n"
+            continue
+          fi
+          ;;
+        docker)
+          # check for podman emulation of docker
+          # if podman is emulating docker, docker --version will return podman --version
+          # which includes 'podman'
+          if docker --version 2>&1 | grep -q podman; then
+            ${quiet} || printf "found 'podman emulating docker'\n"
+            continue
           fi
           ;;
         *)
           # fall through, don't do extra checking
           ;;
       esac
+      ${quiet} || printf "\033[32mfound '%s'\033[0m" "$(${possible} --version)"
+      if [ "${first}" = "true" ]; then
+        ${quiet} || printf "\033[32;1m <- would use without DENV_RUNNER defined\033[0m"
+        first="false"
+      fi
     else
       ${quiet} || printf "not found"
     fi
@@ -977,6 +1003,9 @@ _denv_check() {
   if [ "${first}" = "true" ]; then
     _denv_error "No container runner found!"
     return 2
+  fi
+  if ${denv_runner_defined} && ! ${denv_runner_matched}; then
+    _denv_error "DENV_RUNNER=${DENV_RUNNER} but this runner is not supported by denv"
   fi
   return 0
 }

--- a/denv
+++ b/denv
@@ -905,6 +905,7 @@ _denv_check_help() {
     0   : success, denv installation is complete and there is a supported runner to use
     1   : failure, denv cannot find the entrypoint script it needs
     2   : failure, denv cannot find a supported runner to use
+    3   : failure, DENV_RUNNER is defined to a runner that denv does not support
     127 : denv check was supplied an argument it didn't recognize
 
  OPTIONS
@@ -1006,6 +1007,7 @@ _denv_check() {
   fi
   if ${denv_runner_defined} && ! ${denv_runner_matched}; then
     _denv_error "DENV_RUNNER=${DENV_RUNNER} but this runner is not supported by denv"
+    return 3
   fi
   return 0
 }

--- a/docs/src/manual/denv-check.md
+++ b/docs/src/manual/denv-check.md
@@ -22,7 +22,7 @@ failure condition is encountered.
   - `0`    success, denv installation is complete and there is a supported runner to use (or the user printed the help message)
   - `1`    failure, denv cannot find the entrypoint script as an executable in the directory it is installed in
   - `2`    failure, denv cannot find a supported runner to use
-  - `3`    failure, `DENV_RUNNER` defined to a runner that **`denv`** does not support
+  - `3`    failure, `DENV_RUNNER` defined to a runner that **`denv`** does not support or is not an available program on the machine
   - `4`    failure, denv cannot find a workspace in which it can run from the current directory (user probably missing a `denv init`)
   - `127`  denv check was supplied an argument it didn't recognize
 

--- a/docs/src/manual/denv-check.md
+++ b/docs/src/manual/denv-check.md
@@ -20,6 +20,7 @@ failure condition is encountered.
   - `0`    success, denv installation is complete and there is a supported runner to use (or the user printed the help message)
   - `1`    failure, denv cannot find the entrypoint script as an executable in the directory it is installed in
   - `2`    failure, denv cannot find a supported runner to use
+  - `3`    failure, `DENV_RUNNER` defined to a runner that **`denv`** does not support
   - `127`  denv check was supplied an argument it didn't recognize
 
 # SEE ALSO

--- a/test/config.bats
+++ b/test/config.bats
@@ -26,7 +26,7 @@ teardown() {
 
 @test "basic check run" {
   run denv check
-  assert_output
+  assert_output --partial "denv would run with '${DENV_RUNNER}'"
 }
 
 @test "quiet check run" {

--- a/test/config.bats
+++ b/test/config.bats
@@ -34,6 +34,12 @@ teardown() {
   refute_output
 }
 
+@test "check fails when using unsupported runner" {
+  export DENV_RUNNER=dne
+  run -3 denv check
+  assert_output --partial "runner is not supported by denv"
+}
+
 @test "print config" {
   run denv config print
   assert_line --index 0 "denv_workspace=\"${PWD}\""


### PR DESCRIPTION
This PR adds some new features to `denv check`
1. Look for emulation by inspecting the output of the `version` command to see if a emulator is listed rather than the command itself. This occurs when `singularity` is being "emulated" by `apptainer` (via a simple symlink) and when `docker` is being emulated by `podman` (via a more full program which does CLI translation I assume).
2. Add an _optional_ check for a workspace. This is opt-in so that `denv check` can still be used _before_ `denv init` in order to check its own installation. `denv check --workspace` does all the installation checks as well as looking for an available workspace to run from. This can be helpful for users to debug and make sure that `denv` is picking up the workspace they want it to.
3. Label which runner is specified by `DENV_RUNNER` if it is defined.
4. Error out if `DENV_RUNNER` is defined to a runner that is not supported by denv or is not available on the machine.

# :boom: Breaking Change
After testing the emulation inspection on my NixOS machine, I found that (for `denv`'s purposes) using `podman`'s emulation of `docker` breaks the ownership model we require. With this in mind, I changed the order of runner deduction so that emulators are always checked _before_ the emulated (i.e. podman before docker and apptainer before singularity). This is a breaking change for systems that have both podman and docker installed because now podman will be used by default rather than docker.[^1]

[^1]: By "both installed", I mean docker is not just being emulated by podman. You can check this by running `docker version` and seeing if it calls itself podman or not.