### PR TITLE
add trailing else block to catch everything else

### DIFF
--- a/completions/denv
+++ b/completions/denv
@@ -72,6 +72,11 @@ __denv() {
         COMPREPLY=()
         ;;
     esac
+  else
+    # re-enable default tab-completion for everything else
+    # many workflows require passing file paths and so the default is helpful
+    compopt -o default
+    COMPREPLY=()
   fi
 }
 


### PR DESCRIPTION
I've been annoyed when I notice I can't tab complete path names in positions after the second position and so adding this final else block restore default bash completion for any situation that isn't specific to denv.