### PR TITLE
Enable MacOS GUI Connection

### DIFF
--- a/denv
+++ b/denv
@@ -414,8 +414,17 @@ _denv_deduce_environment() {
   # always add necessary environment variables
   # - DENV_XXX variables for passing information to entrypoint
   # - DISPLAY for connecting X11 GUIs launched from within container to host
+  #   - This needs special consideration for MacOS hosts, we need
+  #     to pass a special value to inform the intermediary VM to connect graphics
   # - HOME for mapping home directory in denv to workspace
-  denv_environment="${denv_environment} DISPLAY=${DISPLAY:+:0}"
+  _display="${DISPLAY:+:0}"
+  if [ "${OSTYPE}" = "darwin"* ] && [ "${denv_runner}" = "docker" ]; then
+    # use the special value for docker to signal that we are attempting
+    # to connect to a host service from within the container
+    # https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+    _display="host.docker.internal:0"
+  fi
+  denv_environment="${denv_environment} DISPLAY=${_display}"
   denv_environment="${denv_environment} DENV_NAME=${denv_name}"
   denv_environment="${denv_environment} DENV_RUNNER=${denv_runner}"
   denv_environment="${denv_environment} DENV_IMAGE=${denv_image}"

--- a/denv
+++ b/denv
@@ -222,6 +222,7 @@ _denv_run() {
   # we will be running now and not writing the config
   # so we can update the denv_mounts list
   [ -d /tmp/.X11-unix ] && denv_mounts="${denv_mounts} /tmp/.X11-unix"
+  [ -f "${XAUTHORITY}" ] && denv_mounts="${denv_mounts} ${XAUTHORITY}"
   denv_mounts="${denv_mounts} ${denv_entrypoint}"
   case "${denv_runner}" in
     docker|podman)
@@ -426,6 +427,7 @@ _denv_deduce_environment() {
     # specify localhost as an allowed source
     _display="host.docker.internal:0"
   fi
+  denv_environment="${denv_environment} XAUTHORITY=${XAUTHORITY}"
   denv_environment="${denv_environment} DISPLAY=${_display}"
   denv_environment="${denv_environment} DENV_NAME=${denv_name}"
   denv_environment="${denv_environment} DENV_RUNNER=${denv_runner}"

--- a/denv
+++ b/denv
@@ -222,7 +222,9 @@ _denv_run() {
   # we will be running now and not writing the config
   # so we can update the denv_mounts list
   [ -d /tmp/.X11-unix ] && denv_mounts="${denv_mounts} /tmp/.X11-unix"
-  [ -f "${XAUTHORITY}" ] && denv_mounts="${denv_mounts} ${XAUTHORITY}"
+  if [ -n "${XAUTHORITY+x}" ] && [ -f "${XAUTHORITY}" ]; then
+    denv_mounts="${denv_mounts} ${XAUTHORITY}"
+  fi
   denv_mounts="${denv_mounts} ${denv_entrypoint}"
   case "${denv_runner}" in
     docker|podman)
@@ -427,7 +429,7 @@ _denv_deduce_environment() {
     # specify localhost as an allowed source
     _display="host.docker.internal:0"
   fi
-  denv_environment="${denv_environment} XAUTHORITY=${XAUTHORITY}"
+  [ -n "${XAUTHORITY+x}" ] && denv_environment="${denv_environment} XAUTHORITY=${XAUTHORITY}"
   denv_environment="${denv_environment} DISPLAY=${_display}"
   denv_environment="${denv_environment} DENV_NAME=${denv_name}"
   denv_environment="${denv_environment} DENV_RUNNER=${denv_runner}"

--- a/denv
+++ b/denv
@@ -418,10 +418,12 @@ _denv_deduce_environment() {
   #     to pass a special value to inform the intermediary VM to connect graphics
   # - HOME for mapping home directory in denv to workspace
   _display="${DISPLAY:+:0}"
-  if [ "${OSTYPE}" = "darwin"* ] && [ "${denv_runner}" = "docker" ]; then
+  if [ "$(uname)" = "Darwin" ] && [ "${denv_runner}" = "docker" ]; then
     # use the special value for docker to signal that we are attempting
     # to connect to a host service from within the container
     # https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+    # MacOS users are required to install XQuartz and
+    # specify localhost as an allowed source
     _display="host.docker.internal:0"
   fi
   denv_environment="${denv_environment} DISPLAY=${_display}"

--- a/denv
+++ b/denv
@@ -1098,6 +1098,20 @@ _denv_check() {
       "(or is not available on this machine)"
     return 3
   fi
+  if [ "$(uname)" = "Darwin" ]; then
+    # check for XQuartz and the xhost configuration
+    gui_incompatible_err=""
+    if ! command -v xhost > /dev/null 2>&1; then
+      gui_incompatible_err="xhost program not found, has XQuartz been installed?"
+    elif xhost | grep -q 'access control enabled'; then
+      gui_incompatible_err="xhost is controlling access, disable it with 'xhost +'."
+    fi
+    if [ "${gui_incompatible_err}" != "" ]; then
+      _denv_error "GUI Interaction on MacOS is not expected to work." \
+        "${gui_incompatible_err}" \
+        "Enabling the GUI Interaction is not necessary but may be desired."
+    fi
+  fi
   if ${workspace}; then
     if [ -z "${denv_workspace+x}" ] && ! _denv_deduce_workspace; then
       _denv_error "Unable to deduce a denv workspace" \

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -72,6 +72,9 @@ within `denv` works fine but making a commit with `git` within it does not.
 The discovery of this limitation and any ongoing work
 is tracked in [denv Issue #102](https://github.com/tomeichlersmith/denv/issues/102).
 
+**Note**: If you wish to use graphical applications from within the denv,
+you will need to install XQuartz[^6] and disable access controll with `xhost +`.
+
 [^2]: [The container is a lie](https://platform.sh/blog/the-container-is-a-lie/) is a nice article going into detail
 about the underpinnings of containers with a bit a click-baity title.Charliecloud's
 [containers are not special](https://hpc.github.io/charliecloud/tutorial.html#containers-are-not-special) 
@@ -90,6 +93,9 @@ graphical interface running outside of WSL (Docker Desktop).
 [^5]: I am not as familiar with the technical underpinnings of how docker or podman on Mac works since
 I have not had a computer to test and learn with it myself. If you have a technical correction to this
 section, please feel free to open an Issue or PR.
+
+[^6]: You can install XQuartz [using brew](https://formulae.brew.sh/cask/xquartz)
+or [using the `.dmg` file](https://www.xquartz.org/).
 
 #### Graphical Applications
 `denv` ensures that the X11 apps spawned from within the container can connect with the host

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -72,9 +72,6 @@ within `denv` works fine but making a commit with `git` within it does not.
 The discovery of this limitation and any ongoing work
 is tracked in [denv Issue #102](https://github.com/tomeichlersmith/denv/issues/102).
 
-**Note**: If you wish to use graphical applications from within the denv,
-you will need to install XQuartz[^6] and disable access controll with `xhost +`.
-
 [^2]: [The container is a lie](https://platform.sh/blog/the-container-is-a-lie/) is a nice article going into detail
 about the underpinnings of containers with a bit a click-baity title.Charliecloud's
 [containers are not special](https://hpc.github.io/charliecloud/tutorial.html#containers-are-not-special) 
@@ -94,9 +91,6 @@ graphical interface running outside of WSL (Docker Desktop).
 I have not had a computer to test and learn with it myself. If you have a technical correction to this
 section, please feel free to open an Issue or PR.
 
-[^6]: You can install XQuartz [using brew](https://formulae.brew.sh/cask/xquartz)
-or [using the `.dmg` file](https://www.xquartz.org/).
-
 #### Graphical Applications
 `denv` ensures that the X11 apps spawned from within the container can connect with the host
 by passing the `DISPLAY` environment variable and mounting the `/tmp/.X11-unix` directory.
@@ -104,12 +98,19 @@ For Linux-hosts and WSL, this is enough[^6]; however, on MacOS additional setup 
 
 If you don't plan to use a graphical application from within the a denv (or if you are just
 using a network-based application like Jupyter Lab), then there is no need to do this
-additional setup on MacOS. [These instructions](https://gist.github.com/roaldnefs/fe9f36b0e8cf2890af14572c083b516c)
-I've found on GitHub are rather short but have worked for many folks.
+additional setup on MacOS. [These instructions](https://gist.github.com/roaldnefs/fe9f36b0e8cf2890af14572c083b516c)[^7]
+which basically amount to installing XQuartz[^8] and then disabling access control
+with `xhost +` (check links for specific, permanent configuration of XQuartz after installation).
 
 [^6]: I haven't tested this thoroughly on WSL, but [WSL's Containers page](https://github.com/microsoft/wslg/blob/main/samples/container/Containers.md)
 appears to support this conclusion as well. This page also implies that `denv` could support Wayland
 applications with a few more mounts and environment variables.
+
+[^7]: Or [these](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088). Honestly, there
+are many tutorials after searching for "docker macos graphics" or similar.
+
+[^8]: You can install XQuartz [using brew](https://formulae.brew.sh/cask/xquartz)
+or [using the `.dmg` file](https://www.xquartz.org/).
 
 ## Installation
 The most recent installation can be obtained by running the install script in the GitHub repository.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -91,6 +91,20 @@ graphical interface running outside of WSL (Docker Desktop).
 I have not had a computer to test and learn with it myself. If you have a technical correction to this
 section, please feel free to open an Issue or PR.
 
+#### Graphical Applications
+`denv` ensures that the X11 apps spawned from within the container can connect with the host
+by passing the `DISPLAY` environment variable and mounting the `/tmp/.X11-unix` directory.
+For Linux-hosts and WSL, this is enough[^6]; however, on MacOS additional setup is required.
+
+If you don't plan to use a graphical application from within the a denv (or if you are just
+using a network-based application like Jupyter Lab), then there is no need to do this
+additional setup on MacOS. [These instructions](https://gist.github.com/roaldnefs/fe9f36b0e8cf2890af14572c083b516c)
+I've found on GitHub are rather short but have worked for many folks.
+
+[^6]: I haven't tested this thoroughly on WSL, but [WSL's Containers page](https://github.com/microsoft/wslg/blob/main/samples/container/Containers.md)
+appears to support this conclusion as well. This page also implies that `denv` could support Wayland
+applications with a few more mounts and environment variables.
+
 ## Installation
 The most recent installation can be obtained by running the install script in the GitHub repository.
 ```shell

--- a/test/gui/README.md
+++ b/test/gui/README.md
@@ -8,22 +8,12 @@ context. Basically, it just installs the xeyes application which will allow
 testers to confirm that the window is shown on screen and the user can
 interact with it.
 
-## Set Up
-Make sure the proof-of-concept image is available, building it if necessary.
-```
-cd image
-docker build . -t xeyes
-cd ..
-```
-Test using the source code of denv, both with environment variable sharing
-enabled and disabled since X11 window sharing does utilize some sharing.
-```
-../../denv init xeyes:latest test
-cd test
-```
+## Run Test
+The `run-gui-test` script is used to do the manual test.
+It makes sure the proof-of-concept image is built and then
+tries to launch `xeyes` using `denv`.
+After `xeyes` is closed, `denv` exits and the temporary workspace is removed.
 
 ```
-../../../denv xeyes
-../../../denv config env all off
-../../../denv xeyes
+./run-gui-test
 ```

--- a/test/gui/run-gui-test
+++ b/test/gui/run-gui-test
@@ -1,48 +1,22 @@
 #!/usr/bin/sh
 
-#   check if we can open xeyes and view it from denv
-#   only run this with docker machines right now
-
-docker_check() {
-  if ! command -v docker > /dev/null 2>&1; then
-    printf "docker not available. Not running test."
-    return 1
-  fi
-  return 0
-}
-
-build_test_image() {
-  cd "${1}" || return 1
-  docker build . -t "${2}"
-}
-
-run_gui_test() {
-  cd "${1}" || return 1
-  "${2}" init --clean-env "${3}:latest" || return 2
-  "${2}" xeyes || return 3
-  cd || return 4
-  rm -r "${1}"
-}
-
+# check if we can open xeyes and view it from denv
+#   using test gui image on GitHub Container Registry
+#   we built which definitely has xeyes in it
 main() {
   _run_gui_test_dir="$(cd -- "$(dirname -- "$0")" && pwd)"
   _denv_dir="$(cd -- "${_run_gui_test_dir}/../../" && pwd)"
   _denv="${_denv_dir}/denv"
-  _test_image_name="denv-gui-test-image"
+  _test_image="ghcr.io/tomeichlersmith/denv-test-gui-image:latest"
 
-  docker_check || return $?
-  
-  build_test_image \
-    "${_run_gui_test_dir}/image" \
-    "${_test_image_name}" || return $?
-  
   # need to accomodate mktemp on either GNU (left) or BSD (right)
   test_d=$(mktemp -d 2> /dev/null || mktemp -d -t 'denv-test-gui-tmpdir')
   
-  run_gui_test \
-    "${test_d}" \
-    "${_test_image_name}" \
-    "${_denv}"
+  cd "${test_d}" || return 1
+  "${_denv}" init --clean-env "${_test_image}" || return 2
+  "${_denv}" xeyes || return 3
+  cd || return 4
+  rm -rf "${test_d}"
 }
 
 main

--- a/test/gui/run-gui-test
+++ b/test/gui/run-gui-test
@@ -1,0 +1,26 @@
+#!/usr/bin/sh
+#   check if we can open xeyes and view it from denv
+#   only run this with docker machines right now
+
+set -o nounset
+set -o errexit
+
+if ! command -v docker > /dev/null 2>&1; then
+  printf "docker not available. Not running test."
+  exit 1
+fi
+
+_run_gui_test_dir="$(cd -- "$(dirname -- "$0")" && pwd)"
+_denv_dir="$(cd -- "${_run_gui_test_dir}/../../" && pwd)"
+_denv="${_denv_dir}/denv"
+_test_image_name="denv-gui-test-image"
+
+cd "${_run_gui_test_dir}/image"
+docker build . -t "${_test_image_name}"
+
+test_d=$(mktemp --directory)
+cd "${test_d}"
+"${_denv}" init --clean-env "${_test_image_name}:latest"
+"${_denv}" xeyes
+cd
+rm -r "${test_d}"

--- a/test/gui/run-gui-test
+++ b/test/gui/run-gui-test
@@ -1,26 +1,48 @@
 #!/usr/bin/sh
+
 #   check if we can open xeyes and view it from denv
 #   only run this with docker machines right now
 
-set -o nounset
-set -o errexit
+docker_check() {
+  if ! command -v docker > /dev/null 2>&1; then
+    printf "docker not available. Not running test."
+    return 1
+  fi
+  return 0
+}
 
-if ! command -v docker > /dev/null 2>&1; then
-  printf "docker not available. Not running test."
-  exit 1
-fi
+build_test_image() {
+  cd "${1}" || return 1
+  docker build . -t "${2}"
+}
 
-_run_gui_test_dir="$(cd -- "$(dirname -- "$0")" && pwd)"
-_denv_dir="$(cd -- "${_run_gui_test_dir}/../../" && pwd)"
-_denv="${_denv_dir}/denv"
-_test_image_name="denv-gui-test-image"
+run_gui_test() {
+  cd "${1}" || return 1
+  "${2}" init --clean-env "${3}:latest" || return 2
+  "${2}" xeyes || return 3
+  cd || return 4
+  rm -r "${1}"
+}
 
-cd "${_run_gui_test_dir}/image"
-docker build . -t "${_test_image_name}"
+main() {
+  _run_gui_test_dir="$(cd -- "$(dirname -- "$0")" && pwd)"
+  _denv_dir="$(cd -- "${_run_gui_test_dir}/../../" && pwd)"
+  _denv="${_denv_dir}/denv"
+  _test_image_name="denv-gui-test-image"
 
-test_d=$(mktemp --directory)
-cd "${test_d}"
-"${_denv}" init --clean-env "${_test_image_name}:latest"
-"${_denv}" xeyes
-cd
-rm -r "${test_d}"
+  docker_check || return $?
+  
+  build_test_image \
+    "${_run_gui_test_dir}/image" \
+    "${_test_image_name}" || return $?
+  
+  # need to accomodate mktemp on either GNU (left) or BSD (right)
+  test_d=$(mktemp -d 2> /dev/null || mktemp -d -t 'denv-test-gui-tmpdir')
+  
+  run_gui_test \
+    "${test_d}" \
+    "${_test_image_name}" \
+    "${_denv}"
+}
+
+main


### PR DESCRIPTION
If a user has XQuartz installed and correctly configured (XQuartz is up and running, network clients are allowed, localhost is an allowed client), then this solution for enabling GUI interaction appears to work.