### PR TITLE
patch invalid var name when using screen

### DIFF
--- a/denv
+++ b/denv
@@ -404,9 +404,9 @@ _denv_deduce_environment() {
   set +o xtrace
   # copy-able environment variables, original code copied from distrobox
   # only get lines defining variables (with '=') and then remove lines
-  # with special characters (space, double-quote, back-tick, dollar-sign, back-slash)
+  # with special characters (space, double-quote, back-tick, dollar-sign)
   # or with special names
-  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$|\\' | grep -Ev "${_denv_bad_env_var_name_regex}=")"
+  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev "${_denv_bad_env_var_name_regex}=")"
   if [ "${denv_env_var_copy_all}" = "true" ]; then
     # deduce env variables, copied from distrobox
     denv_environment="${copyable_environment}"

--- a/denv
+++ b/denv
@@ -389,7 +389,7 @@ _denv_deduce_runner() {
 # | means OR so (one|two) means match one or two
 # combining this means we are matching against env var prefixes listed
 # in the parentheses separated by |
-_denv_bad_env_var_name_regex="^(DENV|HOST|HOME|LANG|LC_CTYPE|.*PATH|SHELL|_|DISPLAY|X)"
+_denv_bad_env_var_name_regex="^(DENV|HOST|HOME|LANG|LC_CTYPE|.*PATH|SHELL|_|DISPLAY|X|.*:.*)"
 
 # deduce the environment we should put into the denv
 # Arguments

--- a/denv
+++ b/denv
@@ -402,8 +402,11 @@ _denv_deduce_environment() {
   # deduce environment variables from configuration
   # disable xtrace here to avoid polluting debug printout
   set +o xtrace
-  # copy-able environment variables, code copied from distrobox
-  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev "${_denv_bad_env_var_name_regex}=")"
+  # copy-able environment variables, original code copied from distrobox
+  # only get lines defining variables (with '=') and then remove lines
+  # with special characters (space, double-quote, back-tick, dollar-sign, back-slash)
+  # or with special names
+  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$|\\' | grep -Ev "${_denv_bad_env_var_name_regex}=")"
   if [ "${denv_env_var_copy_all}" = "true" ]; then
     # deduce env variables, copied from distrobox
     denv_environment="${copyable_environment}"


### PR DESCRIPTION
`screen` creates an environment variable called `TERMCAP` which is split across multiple lines and (I presume) stores some configuration details of `screen`. While the first line of the `TERMCAP` value contains a space and is therefore removed, subsequent lines are not removed by the invalid-value regex and thus result in attempting to pass (for example)
```
        :DO=\E[%dB:LE=\E[%dD:RI=\E[%dC:UP=\E[%dA:bs:bt=\E[Z:\
```
as an environment variable. This gets injected all the way into apptainer's environment injection script which breaks because it parses `:DO` as the environment variable name and colon's are not allowed in POSIX compliant shell environment variable names.

The patch is to also remove variables whose names contain `:`.