### PR TITLE
patch overly strict env var names

### DIFF
--- a/denv
+++ b/denv
@@ -389,7 +389,7 @@ _denv_deduce_runner() {
 # | means OR so (one|two) means match one or two
 # combining this means we are matching against env var prefixes listed
 # in the parentheses separated by |
-_denv_bad_env_var_name_regex="^(DENV|HOST|HOME|LANG|LC_CTYPE|.*PATH|SHELL|_|DISPLAY|X|.*:.*)"
+_denv_bad_env_var_name_regex="^(DENV|HOST|HOME|LANG|LC_CTYPE|.*PATH|SHELL|_|DISPLAY|X)"
 
 # deduce the environment we should put into the denv
 # Arguments
@@ -405,8 +405,10 @@ _denv_deduce_environment() {
   # copy-able environment variables, original code copied from distrobox
   # only get lines defining variables (with '=') and then remove lines
   # with special characters (space, double-quote, back-tick, dollar-sign)
-  # or with special names
-  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev "${_denv_bad_env_var_name_regex}")"
+  # or with special names (matching the regex above)
+  # The last grep checks for colons, if a line has a colon anywhere, an equals sign
+  # must be present before it (i.e. no colons in variable names).
+  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev "${_denv_bad_env_var_name_regex}=" | grep -E "^([^:]*|.*=.*:.*)=")"
   if [ "${denv_env_var_copy_all}" = "true" ]; then
     # deduce env variables, copied from distrobox
     denv_environment="${copyable_environment}"
@@ -688,7 +690,12 @@ _denv_config_env() {
     copy)
       shift
       while [ "$#" -gt "0" ]; do
-        if echo "${1}" | cut -f 1 -d = | grep -E "${_denv_bad_env_var_name_regex}"; then
+        # we are only handling one variable and not lines of variables here
+        # so we can take more care, we first check that the name doesn't match the bad name regex
+        # or has any colons in it
+        # the cut separates out the name by the first equals sign and so we know to fail anything
+        # that has any colon in it
+        if echo "${1}" | cut -f 1 -d = | grep -E "${_denv_bad_env_var_name_regex}|(.*:.*)"; then 
           _denv_error "The passed variables named above are special and should not be used in the denv."
           return 1
         fi

--- a/denv
+++ b/denv
@@ -406,7 +406,7 @@ _denv_deduce_environment() {
   # only get lines defining variables (with '=') and then remove lines
   # with special characters (space, double-quote, back-tick, dollar-sign)
   # or with special names
-  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev "${_denv_bad_env_var_name_regex}=")"
+  copyable_environment="$(printenv | grep '=' | grep -Ev ' |"|`|\$' | grep -Ev "${_denv_bad_env_var_name_regex}")"
   if [ "${denv_env_var_copy_all}" = "true" ]; then
     # deduce env variables, copied from distrobox
     denv_environment="${copyable_environment}"
@@ -688,7 +688,7 @@ _denv_config_env() {
     copy)
       shift
       while [ "$#" -gt "0" ]; do
-        if echo "${1}" | grep -E "${_denv_bad_env_var_name_regex}"; then
+        if echo "${1}" | cut -f 1 -d = | grep -E "${_denv_bad_env_var_name_regex}"; then
           _denv_error "The passed variables named above are special and should not be used in the denv."
           return 1
         fi

--- a/test/env-var.bats
+++ b/test/env-var.bats
@@ -52,3 +52,19 @@ teardown() {
   assert_output --partial "buz"
   assert_output --partial "baz"
 }
+
+@test "env var with special characters" {
+  run -1 denv config env copy bad:name=value
+
+  export colonsep=one=1:two=2
+  denv config env all no
+  denv config env copy colonsep
+  run denv printenv colonsep 
+  assert_success
+  assert_output --partial "one=1:two=2"
+  
+  run denv config env copy colon_sep=three=3:four=4
+  run denv printenv colon_sep 
+  assert_success
+  assert_output --partial "three=3:four=4"
+}

--- a/test/env-var.bats
+++ b/test/env-var.bats
@@ -62,7 +62,8 @@ teardown() {
 @test "env var with multiline value with mimic bad name" {
   # this is like the screen environment variable
   # https://github.com/tomeichlersmith/denv/issues/132
-  export multiline="one=two\nred:blue=green"
+  export multiline="one=two with whitespace
+  red:blue=green"
   run -1 denv printenv multiline
   run denv exit 0
   assert_success

--- a/test/env-var.bats
+++ b/test/env-var.bats
@@ -54,17 +54,31 @@ teardown() {
 }
 
 @test "env var with special characters in name" {
+  # noticed when looking at the screen env var TERMCAP
+  # POSIX-sh does not allow colons in variable names
   run -1 denv config env copy bad:name=value
 }
 
-@test "env var from host with special characteres in value" {
-  export colonsep=one=1:two=2
-  run denv printenv colonsep 
+@test "env var with multiline value with mimic bad name" {
+  # this is like the screen environment variable
+  # https://github.com/tomeichlersmith/denv/issues/132
+  export multiline="one=two\nred:blue=green"
+  run -1 denv printenv multiline
+  run denv exit 0
   assert_success
+}
+
+@test "env var from host with special characteres in value" {
+  # we want to support this type of env var as long as its not broken by whitespace
+  # https://github.com/tomeichlersmith/denv/issues/136
+  export colonsep=one=1:two=2
+  run -0 denv printenv colonsep 
   assert_output --partial "one=1:two=2"
 }
 
 @test "env var on command line with special characters in value" {
+  # we want to support this type of env var as long as its not broken by whitespace
+  # https://github.com/tomeichlersmith/denv/issues/136
   run denv config env copy colon_sep=three=3:four=4
   run denv printenv colon_sep 
   assert_success

--- a/test/env-var.bats
+++ b/test/env-var.bats
@@ -53,16 +53,18 @@ teardown() {
   assert_output --partial "baz"
 }
 
-@test "env var with special characters" {
+@test "env var with special characters in name" {
   run -1 denv config env copy bad:name=value
+}
 
+@test "env var from host with special characteres in value" {
   export colonsep=one=1:two=2
-  denv config env all no
-  denv config env copy colonsep
   run denv printenv colonsep 
   assert_success
   assert_output --partial "one=1:two=2"
-  
+}
+
+@test "env var on command line with special characters in value" {
   run denv config env copy colon_sep=three=3:four=4
   run denv printenv colon_sep 
   assert_success


### PR DESCRIPTION
We just need to be more specific about how we handle colons. They cannot end up within a variable name since that is not supported in shells and thus breaks apptainer's environment injection script but we want to allow them in variable values since they are often used to separate many options. The compromise is to allow them in non-whitespace contexts and have a special check when looking through all environment variables on the host. (Looking at you screen's TERMCAP).