### PR TITLE
warn if denv init inside denv

### DIFF
--- a/denv
+++ b/denv
@@ -918,23 +918,30 @@ _denv_init() {
     _denv_info "Entering '${denv_workspace}'..."
     cd "${denv_workspace}"
   fi
-  # if the workspace was given, we have created and entered it, so the workspace is PWD
-  denv_workspace="${PWD}"
-
-  # check if we already been init'ed
-  if [ -d "${denv_workspace}/.denv" ];then
+  # check if there is a workspace here or "above" (in a parent directory)
+  if _denv_deduce_workspace; then
+    verb="overrid"
+    if [ "${denv_workspace}" = "${PWD}" ]; then
+      verb="overwrit"
+    fi
     if [ "${force}" = "0" ]; then
-      _denv_info "overwriting previous denv workspace"
+      _denv_info "${verb}ing previous denv workspace"
     elif [ -n "${DENV_NOPROMPT+x}" ]; then
-      _denv_error "denv prompt disabled but unwilling to overwrite a denv without user input."
+      _denv_error "denv prompt disabled but unwilling to ${verb}e a denv without user input."
       return 1
-    elif ! _denv_user_confirm "This workspace already has a denv. Would you like to overwrite it?"; then
-      _denv_info "Exiting without overwriting denv within '${denv_workspace}'..."
+    elif ! _denv_user_confirm "This workspace already has a denv (in ${denv_workspace}). Would you like to ${verb}e it?"; then
+      _denv_info "Exiting without ${verb}ing denv within '${denv_workspace}'..."
       return 0
     fi
-  else
-    mkdir "${denv_workspace}/.denv"
   fi
+
+  # if the workspace was given, we have created and entered it,
+  # if it wasn't, we are already in it, so the workspace is PWD
+  denv_workspace="${PWD}"
+
+  # create directory if it doesn't exist,
+  # we need to check in case we are re-initing on top of a denv
+  [ -d "${denv_workspace}/.denv" ] || mkdir "${denv_workspace}/.denv"
 
   # set the default denv name to the workspace directory name
   if [ -z "${denv_name+x}" ]; then

--- a/denv
+++ b/denv
@@ -841,7 +841,7 @@ _denv_init_help() {
  OPTIONS
   -h, --help      : print this help and exit
   --no-gitignore  : don't generate a gitignore for the .denv directory
-  --force         : overwrite an existing denv if it exists and create
+  --force         : overwrite/override an existing denv if it exists and create
                     the WORKSPACE without prompting if it doesn't exist
   --name          : set a name for this denv
   --clean-env     : don't enable copying of host environment variables

--- a/man/man1/denv-init.1
+++ b/man/man1/denv-init.1
@@ -43,6 +43,10 @@ within the developer environment so that the environment can also have
 its own shell configuration files and \f[C]\[ti]/.local\f[R] paths.
 If not provided, we just use the current working directory.
 If provided, we make sure it exists, enter it and then continue.
+If \f[B]\f[CB]WORKSPACE\f[B]\f[R] already has a denv (or one of its
+parent directories has a denv), then the user is prompted on if they
+wish to overwrite (in the case that \f[B]\f[CB]WORKSPACE\f[B]\f[R] itself
+is a denv) or override (otherwise) the already-existing denv.
 .SH EXAMPLES
 .PP
 Print the command line help for \f[B]\f[CB]denv init\f[B]\f[R] without

--- a/test/init.bats
+++ b/test/init.bats
@@ -64,3 +64,11 @@ teardown() {
   assert_success
   assert_file_contains .denv/config '^denv_image="alpine:3.19"$'
 }
+
+@test "denv should not init inside another denv" {
+  run denv init alpine:latest
+  assert_success
+  mkdir subdir
+  cd subdir
+  run ! denv init alpine:latest
+}


### PR DESCRIPTION
When `denv init`ing, make sure to prompt the user if they are going to overwrite (the workspace to-be-initialized already has a denv) or override (a parent directory has a denv). This is helpful to at least make sure that the user acknowledges that they are entering a potentially confusing situation.