### PR TITLE
specialize denv init for script writers

### DIFF
--- a/denv
+++ b/denv
@@ -917,22 +917,24 @@ _denv_init() {
     denv_workspace="$1"
     # check if this directory exists, if not create it
     if [ ! -d "${denv_workspace}" ]; then
-      if [ "${mkwork}" = "1" ]; then
-        _denv_info "creating ${denv_workspace} for the denv workspace"
-      elif [ "${mkwork}" = "0" ]; then
-        _denv_info "refusing to create a directory per user instruction"
-        return 0
+      if [ -n "${mkwork+x}" ]; then
+        if [ "${mkwork}" = "1" ]; then
+          _denv_info "user allows denv to create ${denv_workspace}"
+        elif [ "${mkwork}" = "0" ]; then
+          _denv_info "refusing to create a directory per user instruction"
+          return 0
+        fi
       elif [ -n "${DENV_NOPROMPT+x}" ]; then
         _denv_error "denv prompt disabled but unwilling to create a directory without user input."
         return 1
       elif ! _denv_user_confirm "This directory does not exist. Would you like to create it for the denv?"; then
-        _denv_info "Exiting without creating '${denv_workspace}'..."
+        _denv_info "exiting without creating '${denv_workspace}'..."
         return 0
       fi
-      _denv_info "Creating '${denv_workspace}' for the denv..."
+      _denv_info "creating '${denv_workspace}' for the denv..."
       mkdir "${denv_workspace}"
     fi
-    _denv_info "Entering '${denv_workspace}'..."
+    _denv_info "entering '${denv_workspace}'..."
     cd "${denv_workspace}"
   fi
   # check if there is a workspace here or "above" (in a parent directory)
@@ -941,11 +943,13 @@ _denv_init() {
     if [ "${denv_workspace}" = "${PWD}" ]; then
       verb="overwrit"
     fi
-    if [ "${over}" = "1" ]; then
-      _denv_info "${verb}ing previous denv workspace at ${denv_workspace}"
-    elif [ "${over}" = "0" ]; then
-      _denv_info "refusing to ${verb}e previous denv workspace per user instruction"
-      return 0
+    if [ -n "${over+x}" ]; then
+      if [ "${over}" = "1" ]; then
+        _denv_info "${verb}ing previous denv workspace at ${denv_workspace}"
+      elif [ "${over}" = "0" ]; then
+        _denv_info "refusing to ${verb}e previous denv workspace per user instruction"
+        return 0
+      fi
     elif [ -n "${DENV_NOPROMPT+x}" ]; then
       _denv_error "denv prompt disabled but unwilling to ${verb}e a denv without user input."
       return 1

--- a/denv
+++ b/denv
@@ -860,8 +860,8 @@ _denv_init() {
     _denv_error "Provide at least an image to use for running"
     return 1
   fi
-  copyall=1
-  gitignore=1
+  copyall=true
+  gitignore=true
   positionals=""
   while [ "$#" -gt "0" ]; do
     case "$1" in
@@ -870,26 +870,26 @@ _denv_init() {
         return 0
         ;;
       --no-gitignore)
-        gitignore=0
+        gitignore=false
         ;;
       --clean-env|--no-copy-all)
-        copyall=0
+        copyall=false
         ;;
       --force)
-        over=1
-        mkwork=1
+        over=true
+        mkwork=true
         ;;
       --no-over)
-        over=0
+        over=false
         ;;
       --over)
-        over=1
+        over=true
         ;;
       --no-mkdir)
-        mkwork=0
+        mkwork=false
         ;;
       --mkdir)
-        mkwork=1
+        mkwork=true
         ;;
       --name)
         if [ -z "${2+x}" ]; then
@@ -918,9 +918,9 @@ _denv_init() {
     # check if this directory exists, if not create it
     if [ ! -d "${denv_workspace}" ]; then
       if [ -n "${mkwork+x}" ]; then
-        if [ "${mkwork}" = "1" ]; then
+        if ${mkwork}; then
           _denv_info "user allows denv to create ${denv_workspace}"
-        elif [ "${mkwork}" = "0" ]; then
+        else
           _denv_info "refusing to create a directory per user instruction"
           return 0
         fi
@@ -944,9 +944,9 @@ _denv_init() {
       verb="overwrit"
     fi
     if [ -n "${over+x}" ]; then
-      if [ "${over}" = "1" ]; then
+      if ${over}; then
         _denv_info "${verb}ing previous denv workspace at ${denv_workspace}"
-      elif [ "${over}" = "0" ]; then
+      else
         _denv_info "refusing to ${verb}e previous denv workspace per user instruction"
         return 0
       fi
@@ -954,7 +954,7 @@ _denv_init() {
       _denv_error "denv prompt disabled but unwilling to ${verb}e a denv without user input."
       return 1
     elif ! _denv_user_confirm "This workspace already has a denv (in ${denv_workspace}). Would you like to ${verb}e it?"; then
-      _denv_info "Exiting without ${verb}ing denv within '${denv_workspace}'..."
+      _denv_info "exiting without ${verb}ing denv within '${denv_workspace}'..."
       return 0
     fi
   fi
@@ -976,16 +976,12 @@ _denv_init() {
   denv_shell="/bin/bash -i"
   denv_mounts=""
   denv_network="true"
-  if [ "${copyall}" = "1" ]; then
-    denv_env_var_copy_all="true"
-  else
-    denv_env_var_copy_all="false"
-  fi
+  denv_env_var_copy_all="${copyall}"
   denv_env_var_copy=""
   denv_env_var_set=""
   _denv_write_config
-  if [ "${gitignore}" = "1" ]; then
-    _denv_info "Writing a gitignore for the .denv directory."
+  if ${gitignore}; then
+    _denv_info "writing a gitignore for the .denv directory."
     cat > "${denv_workspace}/.denv/.gitignore" <<\GITIGNORE
 # ignore everything in this directory
 *

--- a/denv
+++ b/denv
@@ -829,8 +829,7 @@ _denv_config() {
 _denv_init_help() {
   cat <<\HELP
 
-  denv init [help|-h|--help] IMAGE [WORKSPACE] [--no-gitignore]
-            [--force] [--name NAME] [--clean-env|--no-copy-all]
+  denv init [OPTIONS] IMAGE [WORKSPACE]
 
  ARGUMENT
   help       : print this help and exit
@@ -841,8 +840,11 @@ _denv_init_help() {
  OPTIONS
   -h, --help      : print this help and exit
   --no-gitignore  : don't generate a gitignore for the .denv directory
-  --force         : overwrite/override an existing denv if it exists and create
-                    the WORKSPACE without prompting if it doesn't exist
+  --[no-]over     : Don't ask about overwrite/override.
+                    Instead just do it (--over) or don't do it (--no-over).
+  --[no-]mkdir    : Don't ask about creating WORKSPACE if it doesn't exist.
+                    Instead just do it (--mkdir) or don't (--no-mkdir).
+  --force         : alias for --over --mkdir
   --name          : set a name for this denv
   --clean-env     : don't enable copying of host environment variables
                     --no-copy-all is another alias which more closely
@@ -860,7 +862,6 @@ _denv_init() {
   fi
   copyall=1
   gitignore=1
-  force=1
   positionals=""
   while [ "$#" -gt "0" ]; do
     case "$1" in
@@ -875,7 +876,20 @@ _denv_init() {
         copyall=0
         ;;
       --force)
-        force=0
+        over=1
+        mkwork=1
+        ;;
+      --no-over)
+        over=0
+        ;;
+      --over)
+        over=1
+        ;;
+      --no-mkdir)
+        mkwork=0
+        ;;
+      --mkdir)
+        mkwork=1
         ;;
       --name)
         if [ -z "${2+x}" ]; then
@@ -903,8 +917,11 @@ _denv_init() {
     denv_workspace="$1"
     # check if this directory exists, if not create it
     if [ ! -d "${denv_workspace}" ]; then
-      if [ "${force}" = "0" ]; then
+      if [ "${mkwork}" = "1" ]; then
         _denv_info "creating ${denv_workspace} for the denv workspace"
+      elif [ "${mkwork}" = "0" ]; then
+        _denv_info "refusing to create a directory per user instruction"
+        return 0
       elif [ -n "${DENV_NOPROMPT+x}" ]; then
         _denv_error "denv prompt disabled but unwilling to create a directory without user input."
         return 1
@@ -924,8 +941,11 @@ _denv_init() {
     if [ "${denv_workspace}" = "${PWD}" ]; then
       verb="overwrit"
     fi
-    if [ "${force}" = "0" ]; then
-      _denv_info "${verb}ing previous denv workspace"
+    if [ "${over}" = "1" ]; then
+      _denv_info "${verb}ing previous denv workspace at ${denv_workspace}"
+    elif [ "${over}" = "0" ]; then
+      _denv_info "refusing to ${verb}e previous denv workspace per user instruction"
+      return 0
     elif [ -n "${DENV_NOPROMPT+x}" ]; then
       _denv_error "denv prompt disabled but unwilling to ${verb}e a denv without user input."
       return 1

--- a/man/man1/denv-init.1
+++ b/man/man1/denv-init.1
@@ -7,9 +7,9 @@
 denv init
 .SH SYNOPSIS
 .PP
-\f[B]denv init\f[R] [help|-h|\[en]help] IMAGE [WORKSPACE]
-[\[en]no-gitignore] [\[en]clean-env|\[en]no-copy-all] [\[en]force]
-[\[en]name NAME]
+\f[B]denv init\f[R] [help|-h|--help] IMAGE [WORKSPACE]
+[--no-gitignore] [--clean-env|--no-copy-all] [--force]
+[--name NAME] [--no-mkdir|--mkdir] [--no-over|--over]
 .SH OPTIONS
 .PP
 \f[B]\f[CB]--help\f[B]\f[R], \f[B]\f[CB]-h\f[B]\f[R], or
@@ -32,6 +32,13 @@ the current workspace has one
 .PP
 \f[B]\f[CB]--name\f[B]\f[R] sets the name for the denv workspace that is
 being initialized to NAME
+.PP
+\f[B]\f[CB]--[no-]mkdir\f[B]\f[R] don't prompt about if denv can create the
+workspace directory. Just do it (--mkdir) or not (--no-mkdir).
+.PP
+\f[B]\f[CB]--[no-]over\f[B]\f[R] don't prompt about if denv should overwrite
+a configuration within the workspace or override a configuration in a parent directory.
+Just do it (--over) or not (--no-over).
 .SH ARGUMENTS
 .PP
 \f[B]\f[CB]IMAGE\f[B]\f[R] the name of a container image to use when
@@ -97,6 +104,22 @@ different names.
 denv init python:3.11 py311
 \f[R]
 .fi
+.PP
+As a standalone program, \f[B]denv\f[R] can be used within other scripts
+and support programs.
+With this in mind, a common process is to have a denv configuration that
+can be ensured to exist for the rest of additional tasks.
+The following example uses the --no-mkdir and --no-over flags to silently
+ensure that the present working directory has the python:3.11 image configured.
+.IP
+.nf
+\f[C]denv init --no-mkdir --no-over python:3.11\f[R]
+.fi
+.PP
+WARNING: \f[B]denv init\f[R] does not ensure that the image is the same as
+the one passed, it just quielty refused to overwrite an existing configuration
+allowing it to be quickly bypassed if the configuration has already been made
+or initialize the configuration if no configuration is present.
 .SH DEFAULT CONFIGURATION
 .PP
 \f[B]denv init\f[R] makes the following choices on configuration that

--- a/test/init.bats
+++ b/test/init.bats
@@ -59,10 +59,25 @@ teardown() {
   assert_success
   run ! denv init alpine:latest
   assert_failure
-  # but can be forced
-  run -0 denv init --force alpine:3.19
+}
+
+@test "denv can init twice with force" {
+  run denv init alpine:latest
+  assert_success
+  run denv init --force alpine:3.19
   assert_success
   assert_file_contains .denv/config '^denv_image="alpine:3.19"$'
+  run denv init --over alpine:latest
+  assert_success
+  assert_file_contains .denv/config '^denv_image="alpine:latest"$'
+}
+
+@test "denv can skip double init without force" {
+  run denv init alpine:latest
+  assert_success
+  run denv init --no-over alpine:3.19
+  assert_success
+  assert_file_contains .denv/config '^denv_image="alpine:latest"$'
 }
 
 @test "denv should not init inside another denv" {
@@ -71,4 +86,22 @@ teardown() {
   mkdir subdir
   cd subdir
   run ! denv init alpine:latest
+}
+
+@test "denv can force init inside another denv" {
+  run denv init alpine:latest
+  assert_success
+  mkdir subdir
+  cd subdir
+  run denv init --over alpine:latest
+  assert_success
+}
+
+@test "denv will not create new directory by default" {
+  run ! denv init alpine:latest subdir
+}
+
+@test "denv can be told to create new directory by default" {
+  run denv init --mkdir alpine:latest subdir
+  assert_success
 }

--- a/test/init.bats
+++ b/test/init.bats
@@ -57,7 +57,7 @@ teardown() {
 @test "denv should not init twice" {
   run denv init alpine:latest
   assert_success
-  run ! denv init alpine:latest
+  run -1 denv init alpine:latest
   assert_failure
 }
 
@@ -85,7 +85,7 @@ teardown() {
   assert_success
   mkdir subdir
   cd subdir
-  run ! denv init alpine:latest
+  run -1 denv init alpine:latest
 }
 
 @test "denv can force init inside another denv" {
@@ -98,7 +98,7 @@ teardown() {
 }
 
 @test "denv will not create new directory by default" {
-  run ! denv init alpine:latest subdir
+  run -1 denv init alpine:latest subdir
 }
 
 @test "denv can be told to create new directory by default" {


### PR DESCRIPTION
This introduces four new command line flags to the `denv init` CLI making it easier for script writers to avoid the user prompt if desired. This follows the idea outlined in https://github.com/tomeichlersmith/denv/pull/140#issuecomment-2392305916