### PR TITLE
piggy-back on apptainer SIF image cache

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -109,10 +109,19 @@ if [ -z "${runners}" ]; then
 fi
 
 for runner in ${runners}; do
-  _denv_info "Testing denv with '${runner}'"
-  if [ "${runner}" = "norunner" ]; then
-    DENV_RUNNER="${runner}" ./test/bats/bin/bats --filter-tags "norunner" test/
-  else
-    DENV_RUNNER="${runner}" ./test/bats/bin/bats test/
-  fi
+  filter_tags=""
+  case "${runner}" in
+    norunner)
+      filter_tags="--filter-tags norunner"
+      ;;
+    docker|podman)
+      filter_tags="--filter-tags !apptainer"
+      ;;
+    *)
+      filter_tags=""
+      ;;
+  esac
+  _denv_info "Testing denv with '${runner}' ${filter_tags}"
+  # shellcheck disable=SC2068
+  DENV_RUNNER="${runner}" ./test/bats/bin/bats ${filter_tags} test/
 done

--- a/denv
+++ b/denv
@@ -194,7 +194,7 @@ _denv_pull() {
         if [ "${denv_runner}" = "apptainer" ]; then
           container_env_var="APPTAINER_CONTAINER"
         else
-          container_env_var="SINGULARITY_IMAGE"
+          container_env_var="SINGULARITY_CONTAINER"
         fi
         # we pass the full image name including registry to be run by apptainer/singularity
         # this then allows us to retrieve the full path to the cached SIF image file

--- a/denv
+++ b/denv
@@ -181,9 +181,9 @@ _denv_pull() {
       if [ -e "${denv_image}" ]; then
         _denv_info "This path exists on the filesystem, assuming unpacked image."
         # if the passed image is a file system path,
-        # we assume it is an already unpacked image
+        # we assume it is an image (unpacked or SIF)
         # and so we just symlink to it in our cache
-        ln -s "${denv_image}" "${sif_file}" 
+        ln -sf "${denv_image}" "${sif_file}" 
       else
         _denv_info "Image does not exist on filesystem, assuming registry tag."
         # passed image is not a file so we assume it
@@ -191,10 +191,17 @@ _denv_pull() {
         # using the docker:// registry as default
         image_full="${denv_image}"
         echo "${denv_image}" | grep -v '://' && image_full="docker://${denv_image}"
-        ${denv_runner} build \
-          --force \
-          "${sif_file}" \
-          "${image_full}"
+        if [ "${denv_runner}" = "apptainer" ]; then
+          container_env_var="APPTAINER_CONTAINER"
+        else
+          container_env_var="SINGULARITY_IMAGE"
+        fi
+        # we pass the full image name including registry to be run by apptainer/singularity
+        # this then allows us to retrieve the full path to the cached SIF image file
+        # that is constructed from the OCI image
+        # then we link this cached image file to our local image cache
+        cached_image=$(${denv_runner} run "${image_full}" printenv "${container_env_var}")
+        ln -sf "${cached_image}" "${sif_file}"
       fi
       ;;
     norunner)

--- a/test/apptainer.bats
+++ b/test/apptainer.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "test_helper/denv"
+  common_setup
+  
+  go_to_tmp_work
+  denv init alpine:latest
+}
+
+teardown() {
+  clean_tmp_work
+}
+
+# bats file_tags=apptainer
+
+@test "normal running works" {
+  run -0 denv true
+  assert_success
+}
+
+@test "can invalidate cache and then run" {
+  rm -r ${APPTAINER_CACHEDIR}
+  run -0 denv true
+  assert_success
+}

--- a/test/apptainer.bats
+++ b/test/apptainer.bats
@@ -16,11 +16,22 @@ teardown() {
 
 @test "normal running works" {
   run -0 denv true
-  assert_success
 }
 
 @test "can invalidate cache and then run" {
-  rm -r ${APPTAINER_CACHEDIR}
+  case "${DENV_RUNNER}" in
+    apptainer)
+      cache=${APPTAINER_CACHEDIR:-${HOME}/.apptainer/cache}
+      ;;
+    singularity)
+      cache=${SINGULARITY_CACHEDIR:-${HOME}/.singularity/cache}
+      ;;
+    *)
+      echo "This test is only designed for apptainer/singularity, not ${DENV_RUNNER}."
+      echo "Re-run with '--filter-tags !apptainer' to test ${DENV_RUNNER}"
+      false
+      ;;
+  esac
+  rm -r ${cache}
   run -0 denv true
-  assert_success
 }


### PR DESCRIPTION
This resolves #141 for `apptainer` but not the other singularity flavors.

`apptainer` has an in-container environment variable `APPTAINER_CONTAINER` that holds the full path to the SIF image that was used to launch the container.[^1] This environment variable is not documented, but is exactly what we want since it allows us to use `apptainer` to cache a local copy of the SIF image built from an OCI image and then we just launch it to retrieve the path to this cached image.

[^1]: https://github.com/apptainer/apptainer/blob/e6fc6f0d5862a372241a8bec50b980036e37975e/internal/pkg/runtime/launch/launcher_linux.go#L526

The other singularity flavors are supported as before, manually building the SIF image ourselves, meaning different denvs must have their own copy of the image even if the two are identical and owned by the same user.

Leaving this as draft in order to
- [x] see if a similar environment variable can be found for the other singularity flavors
- [x] is there a better way to do this? I think this is the "correct" way to do this as far as I can tell from looking through the documentation and code. apptainer/singularity really don't want folks to rely on the cache especially when running multiple containers from the same image which makes sense and motivates me to update the documentation accordingly.
- [x] add test that makes sure users can invalidate the cache and the image is rebuilt seamlessly
- [x] update documentation: as pointed out in [apptainer's cache documentation](https://apptainer.org/docs/user/1.3/build_env.html#sec-cache), if the filesystem the cache is residing in does not support atomic renaming, then running the image from that location may see performance issues (reading between the lines here). I'd like to point this out in the `denv` docs. `denv` supports running from a manually built SIF image as well, so if users are preparing a cluster-wide processing campaign, they should manually build and fix a SIF that they can then provide `denv`.