### PR TITLE
prompt user about creating denv in host home directory

### DIFF
--- a/denv
+++ b/denv
@@ -869,7 +869,10 @@ _denv_init_help() {
                     Instead just do it (--over) or don't do it (--no-over).
   --[no-]mkdir    : Don't ask about creating WORKSPACE if it doesn't exist.
                     Instead just do it (--mkdir) or don't (--no-mkdir).
-  --force         : alias for --over --mkdir
+  --[no-]host-home: Don't ask about allowing a denv where WORKSPACE is the host
+                    home directory. Instead just do it (--host-home) or don't
+                    (--no-host-home).
+  --force         : alias for --over --mkdir --host-home
   --name          : set a name for this denv
   --clean-env     : don't enable copying of host environment variables
                     --no-copy-all is another alias which more closely
@@ -915,6 +918,12 @@ _denv_init() {
         ;;
       --mkdir)
         mkwork=true
+        ;;
+      --host-home)
+        host_home=true
+        ;;
+      --no-host-home)
+        host_home=false
         ;;
       --name)
         if [ -z "${2+x}" ]; then
@@ -997,6 +1006,24 @@ _denv_init() {
   # if the workspace was given, we have created and entered it,
   # if it wasn't, we are already in it, so the workspace is PWD
   denv_workspace="${PWD}"
+
+  # check if workspace is the host's home directory
+  if [ "${denv_workspace}" = "${HOME}" ]; then
+    if [ -n "${host_home+x}" ]; then
+      if ${host_home}; then
+        _denv_info "Allowing a denv to exist in the host home directory as instructed by command line --host-home."
+      else
+        _denv_error "Refusing to create a denv within the host home directory."
+        return 1
+      fi
+    elif [ -n "${DENV_NOPROMPT+x}" ]; then
+      _denv_error "Refusing to create a denv within the host home directory without user input."
+      return 1;
+    elif ! _denv_user_confirm "Creating a denv within your home directory can lead to issues. Do you wish to continue?"; then
+      _denv_info "exiting without creating denv within the home directory"
+      return 0
+    fi
+  fi
 
   # create directory if it doesn't exist,
   # we need to check in case we are re-initing on top of a denv

--- a/man/man1/denv-init.1
+++ b/man/man1/denv-init.1
@@ -10,6 +10,7 @@ denv init
 \f[B]denv init\f[R] [help|-h|--help] IMAGE [WORKSPACE]
 [--no-gitignore] [--clean-env|--no-copy-all] [--force]
 [--name NAME] [--no-mkdir|--mkdir] [--no-over|--over]
+[--no-host-home|--host-home]
 .SH OPTIONS
 .PP
 \f[B]\f[CB]--help\f[B]\f[R], \f[B]\f[CB]-h\f[B]\f[R], or
@@ -39,6 +40,10 @@ workspace directory. Just do it (--mkdir) or not (--no-mkdir).
 \f[B]\f[CB]--[no-]over\f[B]\f[R] don't prompt about if denv should overwrite
 a configuration within the workspace or override a configuration in a parent directory.
 Just do it (--over) or not (--no-over).
+.PP
+\f[B]\f[CB]--[no-]host-home\f[B]\f[R] don't prompt about if denv should allow a workspace
+to be the host's home directory.
+Just do it (--host-home) or not (--no-host-home).
 .SH ARGUMENTS
 .PP
 \f[B]\f[CB]IMAGE\f[B]\f[R] the name of a container image to use when

--- a/man/man1/denv-init.1
+++ b/man/man1/denv-init.1
@@ -44,6 +44,9 @@ Just do it (--over) or not (--no-over).
 \f[B]\f[CB]--[no-]host-home\f[B]\f[R] don't prompt about if denv should allow a workspace
 to be the host's home directory.
 Just do it (--host-home) or not (--no-host-home).
+Since the denv and the host environment can be very different, having them share a home
+directory and the resulting configuration files (e.g. \f[C].bashrc\f[R]) is generally a bad
+idea and can lead to a lot of confusing behavior.
 .SH ARGUMENTS
 .PP
 \f[B]\f[CB]IMAGE\f[B]\f[R] the name of a container image to use when

--- a/man/man1/denv.1
+++ b/man/man1/denv.1
@@ -110,11 +110,12 @@ installed and you wish to override the default denv behavior of using
 the first runner that it finds available.
 .PP
 \f[B]DENV_NOPROMPT\f[R] disable all user prompting.
-This makes the following decisions in the places where there would be
-prompts.
+This affects the \f[B]denv init\f[R] and \f[B]denv config image\f[R] commands.
 .IP \[bu] 2
-\f[B]denv init\f[R] errors out if there is already a denv in the deduced
-workspace or if a passed workspace does not exist
+\f[B]denv init\f[R], without any special command line flags, errors out if
+there is already a denv in the deduced workspace or parent directory of the
+workspace, the passed workspace does not exist, or if the workspace is the
+home directory.
 .IP \[bu] 2
 \f[B]denv init\f[R] and \f[B]denv config image\f[R] will not pull an
 image if it already exists

--- a/test/init.bats
+++ b/test/init.bats
@@ -129,3 +129,11 @@ teardown() {
   cd "one?two"
   run -2 denv init alpine:latest
 }
+
+@test "refuse to init in host home directory #163" {
+  # avoid permission issues and re-copying images
+  # by symlinking the local directories here
+  ln -st . ${HOME}/.cache ${HOME}/.config ${HOME}/.local
+  export HOME=${PWD}
+  run -2 denv init alpine:latest
+}

--- a/test/init.bats
+++ b/test/init.bats
@@ -135,5 +135,5 @@ teardown() {
   # by symlinking the local directories here
   ln -st . ${HOME}/.cache ${HOME}/.config ${HOME}/.local
   export HOME=${PWD}
-  run -2 denv init alpine:latest
+  run -1 denv init alpine:latest
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -7,6 +7,8 @@ setup_file() {
   go_to_tmp_work
   denv init python
   cp -t . ${OLDPWD}/test/internet-access.py
+  # dummy command to force pull the image if it hasn't been pulled yet
+  denv true
 }
 
 setup() {


### PR DESCRIPTION
This resolves #163 

- new command line flags for enabling/disabling home directory check
- prompt user if no command line flags are given
- update manual with these flags and a short explanation why